### PR TITLE
First pass at inverse immune relations, #105

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -924,6 +924,31 @@ range: spatial region or site (immaterial continuant)
     
 
 
+    <!-- http://purl.obolibrary.org/obo/RO_0001022 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001022">
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0003302"/>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0001020"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <obo:IAO_0000112>penicillin allergy (DOID:0060520) has allergic trigger penicillin (CHEBI:17334)</obo:IAO_0000112>
+        <obo:IAO_0000115>A relation between a condition (a phenotype or disease) of a host and a material entity, in which the material entity is not part of the host, and is considered harmless to non-allergic hosts, and the condition results in pathological processes that include an abnormally strong immune response against the material entity.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">has allergic trigger</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0001023 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001023">
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0003302"/>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0001021"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <obo:IAO_0000115>A relation between a condition (a phenotype or disease) of a host and a material entity, in which the material entity is part of the host itself, and the condition results in pathological processes that include an abnormally strong immune response against the material entity.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">has autoimmune trigger</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/RO_0002000 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002000">


### PR DESCRIPTION
It would be convenient to have the inverses of the two relations from #105.

Potential problem: As defined here, these forward and inverse versions use the same parent 'causes or contributes to condition'. Maybe the inverses need a different parent.