### PR TITLE
Remove is_a from ro-chado.obo

### DIFF
--- a/subsets/ro-chado.obo
+++ b/subsets/ro-chado.obo
@@ -17,11 +17,6 @@ property_value: http://purl.org/dc/elements/1.1/title "OBO Relations Ontology" x
 property_value: http://xmlns.com/foaf/0.1/homepage " https://github.com/oborel/obo-relations/" xsd:anyURI
 
 [Typedef]
-id: OBO_REL:is_a
-name: is_a
-comment: This relation is added for backward compatibility with Chado
-
-[Typedef]
 id: BFO:0000050
 name: part_of
 def: "a core relation that holds between a part and its whole" []

--- a/subsets/ro-chado.obo
+++ b/subsets/ro-chado.obo
@@ -17,6 +17,11 @@ property_value: http://purl.org/dc/elements/1.1/title "OBO Relations Ontology" x
 property_value: http://xmlns.com/foaf/0.1/homepage " https://github.com/oborel/obo-relations/" xsd:anyURI
 
 [Typedef]
+id: OBO_REL:is_a
+name: is_a
+comment: This relation is added for backward compatibility with Chado
+
+[Typedef]
 id: BFO:0000050
 name: part_of
 def: "a core relation that holds between a part and its whole" []
@@ -3031,9 +3036,4 @@ name: results_in_morphogenesis_of
 def: "The relationship that links an entity with the process that results in the formation and shaping of that entity over time from an immature to a mature state." []
 is_a: results_in_developmental_progression_of ! results in developmental progression of
 is_a: RO:0000057 ! has participant
-
-[Typedef]
-id: OBO_REL:is_a
-name: is_a
-comment: This relation is added for backward compatibility with Chado
 


### PR DESCRIPTION
As discussed in erasche/docker-tripal#6, we have a problem loading ro-chado.obo in chado.
It looks like removing "OBO_REL:is_a" from ro-chado fixes the problem.