### PR TITLE
changing default namespace from "ro" to "relationship"; *many* pieces…

### DIFF
--- a/subsets/ro-chado.obo
+++ b/subsets/ro-chado.obo
@@ -9,7 +9,7 @@ remark: Includes Ontology(OntologyID(OntologyIRI(<http://purl.obolibrary.org/obo
 remark: Includes Ontology(OntologyID(OntologyIRI(<http://purl.obolibrary.org/obo/ro/pato_import.owl>))) [Axioms: 20 Logical Axioms: 6]
 remark: Includes Ontology(OntologyID(OntologyIRI(<http://purl.obolibrary.org/obo/ro/rohom.owl>))) [Axioms: 731 Logical Axioms: 148]
 remark: Includes Ontology(OntologyID(OntologyIRI(<http://purl.obolibrary.org/obo/ro/temporal-intervals.owl>))) [Axioms: 146 Logical Axioms: 45]
-default-namespace: ro
+default-namespace: relationship
 ontology: ro/subsets/ro-chado.obo
 property_value: http://purl.org/dc/elements/1.1/description "The OBO Relations Ontology (RO) is a collection of OWL relations (ObjectProperties) intended for use across a wide variety of biological ontologies." xsd:string
 property_value: http://purl.org/dc/elements/1.1/source http://obofoundry.org/ro


### PR DESCRIPTION
… of software expect relationship terms to be in a cv called "relationship"