### PR TITLE
Removed transformation of subPropertyOf preceded_by. Fixes #126

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -5374,7 +5374,6 @@ the a supports either the existence of b, or the truth value of b.</obo:IAO_0000
     <!-- http://purl.obolibrary.org/obo/RO_0002494 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002494">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000062"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002202"/>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <obo:IAO_0000115>x transformation of y if x is the immediate transformation of y, or is linked to y through a chain of transformation relationships</obo:IAO_0000115>
@@ -5387,7 +5386,6 @@ the a supports either the existence of b, or the truth value of b.</obo:IAO_0000
     <!-- http://purl.obolibrary.org/obo/RO_0002495 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002495">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002087"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002207"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002494"/>
         <obo:IAO_0000115>x immediate transformation of y iff x immediately succeeds y temporally at a time boundary t, and all of the matter present in x at t is present in y at t, and all the matter in y at t is present in x at t</obo:IAO_0000115>
@@ -7493,8 +7491,8 @@ Environments include natural environments or exposures, experimentally applied c
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002222">
         <obo:IAO_0000232>Do not use this relation directly. It is ended as a grouping for relations between occurrents involving the relative timing of their starts and ends.</obo:IAO_0000232>
-        <obo:IAO_0000117>Chris Mungall</obo:IAO_0000117>
         <dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://docs.google.com/document/d/1kBv1ep_9g3sTR-SD3jqzFqhuwo9TPNF-l-9fUDbO6rM/edit?pli=1</dc:source>
+        <obo:IAO_0000117>Chris Mungall</obo:IAO_0000117>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/ro/subsets#ro-eco"/>
     </rdf:Description>
     <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy">


### PR DESCRIPTION
```
gitowl
gitowl ||  Diffing:  src/ontology/ro-edit.owl
gitowl ||
gitowl ||  subject: http://purl.obolibrary.org/obo/RO_0002494
gitowl --  SubObjectPropertyOf(obo:RO_0002494 obo:BFO_0000062)
gitowl ||      transformation of SubPropertyOf BFO_0000062
gitowl ||
gitowl ||  subject: http://purl.obolibrary.org/obo/RO_0002495
gitowl --  SubObjectPropertyOf(obo:RO_0002495 obo:RO_0002087)
gitowl ||      immediate transformation of SubPropertyOf RO_0002087
gitowl
```