### PR TITLE
Remove inverse expression superproperty for ‘enabled by’.

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -2921,7 +2921,6 @@ AnnotationAssertion(obo:IAO_0000115 obo:RO_0002333 "inverse of enables")
 AnnotationAssertion(obo:IAO_0000117 obo:RO_0002333 "Chris Mungall")
 AnnotationAssertion(rdfs:label obo:RO_0002333 "enabled by"@en)
 SubObjectPropertyOf(obo:RO_0002333 obo:RO_0002328)
-SubObjectPropertyOf(obo:RO_0002333 ObjectInverseOf(obo:RO_0002215))
 
 # Object Property: obo:RO_0002334 (regulated by)
 


### PR DESCRIPTION
Removes `'enabled by' SubPropertyOf inverse('capable of')` and fixes #242. I believe this axiom is redundant anyway, since we have:

- `'enabled by' InverseOf 'enables'`
- `'enables' SubPropertyOf 'capable of'`