### PR TITLE
Correct ‘directly develops from’ definition error.

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -2088,7 +2088,7 @@ ObjectPropertyRange(obo:RO_0002206 obo:CARO_0000006)
 # Object Property: obo:RO_0002207 (directly develops from)
 
 AnnotationAssertion(obo:IAO_0000114 obo:RO_0002207 obo:IAO_0000125)
-AnnotationAssertion(obo:IAO_0000115 obo:RO_0002207 "Candidate definition: x directly_develops from y if and only if there exists some developmental process (GO:0032502) p such that x and y both participates in p, and x is the output of p and y is the input of p, and a substantial portion of the matter of y comes from x, and the start of x is coincident with or after the end of y")
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0002207 "Candidate definition: x directly_develops from y if and only if there exists some developmental process (GO:0032502) p such that x and y both participate in p, and x is the output of p and y is the input of p, and a substantial portion of the matter of x comes from y, and the start of x is coincident with or after the end of y.")
 AnnotationAssertion(obo:IAO_0000117 obo:RO_0002207 "Chris Mungall")
 AnnotationAssertion(obo:IAO_0000117 obo:RO_0002207 "David Osumi-Sutherland")
 AnnotationAssertion(obo:IAO_0000117 obo:RO_0002207 "has developmental precursor")


### PR DESCRIPTION
See #292.