### PR TITLE
Fix wikipedia URL in `rohom.owl`

### DIFF
--- a/src/ontology/rohom.owl
+++ b/src/ontology/rohom.owl
@@ -934,7 +934,7 @@
     <owl:Axiom>
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Convergence that results from co-evolution usually involving an evolutionary arms race.</owl:annotatedTarget>
         <oboInOwl:hasDbXref rdf:resource="http://purl.obolibrary.org/obo/HOM_0000033"/>
-        <oboInOwl:hasDbXref rdf:resource="http:://en.wikipedia.org/wiki/Mimicry"/>
+        <oboInOwl:hasDbXref rdf:resource="http://en.wikipedia.org/wiki/Mimicry"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/RO_HOM0000033"/>
     </owl:Axiom>


### PR DESCRIPTION
`rohom.owl` contains an invalid URL to a Wikipedia cross-reference, that ends up in `ro.obo` when building the ontology.