### PR TITLE
Update ro-base.owl

### DIFF
--- a/ro-base.owl
+++ b/ro-base.owl
@@ -6185,6 +6185,7 @@ For example, A and B may be gene products and binding of B by A positively regul
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002454">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002440"/>
         <obo:IAO_0000117>Chris Mungall</obo:IAO_0000117>
+	<obo:IAO_0000115>"X 'has host' y if and only if: x is an organism, y is an organism, and x can live on the surface of or within the body of y"</obo:IAO_0000115>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/ro/subsets#ro-eco"/>
         <rdfs:label>has host</rdfs:label>
         <rdfs:seeAlso>http://eol.org/schema/terms/hasHost</rdfs:seeAlso>


### PR DESCRIPTION
added definition for http://purl.obolibrary.org/obo/RO_0002454, "has host":  "X 'has host' y if and only if: x is an organism, y is an organism, and x can live on the surface of or within the body of y"