### PR TITLE
Update ro-edit.owl

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -3817,6 +3817,7 @@ SubObjectPropertyOf(obo:RO_0002453 obo:RO_0002440)
 
 AnnotationAssertion(obo:IAO_0000117 obo:RO_0002454 "Chris Mungall")
 AnnotationAssertion(oboInOwl:inSubset obo:RO_0002454 subsets:ro-eco)
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0002454 "X 'has host' y if and only if: x is an organism, y is an organism, and x can live on the surface of or within the body of y")
 AnnotationAssertion(rdfs:label obo:RO_0002454 "has host")
 AnnotationAssertion(rdfs:seeAlso obo:RO_0002454 "http://eol.org/schema/terms/hasHost")
 SubObjectPropertyOf(obo:RO_0002454 obo:RO_0002440)


### PR DESCRIPTION
trying again!

added definition for http://purl.obolibrary.org/obo/RO_0002454, "has host": "X 'has host' y if and only if: x is an organism, y is an organism, and x can live on the surface of or within the body of y"