### PR TITLE
Remove incorrect domain from 'relation between physical entity and a process or stage'.

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -4154,7 +4154,6 @@ AnnotationAssertion(obo:IAO_0000117 obo:RO_0002487 "Chris Mungall")
 AnnotationAssertion(obo:IAO_0000232 obo:RO_0002487 "Do not use this relation directly. It is ended as a grouping for a diverse set of relations, typically connecting an anatomical entity to a biological process or developmental stage.")
 AnnotationAssertion(rdfs:label obo:RO_0002487 "relation between physical entity and a process or stage")
 ObjectPropertyDomain(obo:RO_0002487 obo:BFO_0000004)
-ObjectPropertyDomain(obo:RO_0002487 ObjectUnionOf(obo:CARO_0000006 obo:CARO_0000007))
 ObjectPropertyRange(obo:RO_0002487 obo:BFO_0000003)
 
 # Object Property: obo:RO_0002488 (existence starts during)


### PR DESCRIPTION
Fixes #423.