### PR TITLE
Implement chain 'acts upstream of or within' o 'causally upstream of' -> 'acts upstream of' as a SWRL rule

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -6355,6 +6355,7 @@ DLSafeRule(Annotation(rdfs:label "'causally downstream of' and 'overlaps' should
 DLSafeRule(Annotation(rdfs:label "'causally upstream of' and 'overlaps' should be disjoint properties (a SWRL rule is required because these are non-simple properties).") Body(ObjectPropertyAtom(obo:RO_0002411 Variable(<urn:swrl#x>) Variable(<urn:swrl#y>)) ObjectPropertyAtom(obo:RO_0002131 Variable(<urn:swrl#x>) Variable(<urn:swrl#y>)))Head(ClassAtom(owl:Nothing Variable(<urn:swrl#x>)) ClassAtom(owl:Nothing Variable(<urn:swrl#y>))))
 DLSafeRule(Body(ObjectPropertyAtom(obo:RO_0002213 Variable(<urn:swrl#y>) Variable(<urn:swrl#z>)) ObjectPropertyAtom(obo:RO_0002212 Variable(<urn:swrl#x>) Variable(<urn:swrl#y>)))Head(ObjectPropertyAtom(obo:RO_0002212 Variable(<urn:swrl#x>) Variable(<urn:swrl#z>))))
 DLSafeRule(Body(ObjectPropertyAtom(obo:RO_0002213 Variable(<urn:swrl#x>) Variable(<urn:swrl#y>)) ObjectPropertyAtom(obo:RO_0002212 Variable(<urn:swrl#y>) Variable(<urn:swrl#z>)))Head(ObjectPropertyAtom(obo:RO_0002212 Variable(<urn:swrl#x>) Variable(<urn:swrl#z>))))
+DLSafeRule(Body(ObjectPropertyAtom(obo:RO_0002411 Variable(<urn:swrl:var#y>) Variable(<urn:swrl:var#z>)) ObjectPropertyAtom(obo:RO_0002264 Variable(<urn:swrl:var#x>) Variable(<urn:swrl:var#y>)))Head(ObjectPropertyAtom(obo:RO_0002263 Variable(<urn:swrl:var#x>) Variable(<urn:swrl:var#z>))))
 AnnotationAssertion(owl:deprecated obo:BFO_0000060 "true"^^xsd:boolean)
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0000092 "inverse of has disposition")
 AnnotationAssertion(oboInOwl:inSubset obo:RO_0000092 obo:RO_0002259)


### PR DESCRIPTION
Add the rule: `'acts upstream of or within'(?x, ?y), 'causally upstream of'(?y, ?z) -> 'acts upstream of'(?x, ?z)`

This could be a property chain, but would violate cycle restrictions from OWL DL.

Motivation comes from GO-CAM reasoning: https://github.com/geneontology/minerva/issues/394