### PR TITLE
add "has component participant" object property

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -150,6 +150,7 @@ Declaration(ObjectProperty(obo:RO_0002234))
 Declaration(ObjectProperty(obo:RO_0002235))
 Declaration(ObjectProperty(obo:RO_0002236))
 Declaration(ObjectProperty(obo:RO_0002237))
+Declaration(ObjectProperty(obo:RO_0002238))
 Declaration(ObjectProperty(obo:RO_0002240))
 Declaration(ObjectProperty(obo:RO_0002241))
 Declaration(ObjectProperty(obo:RO_0002242))
@@ -2458,6 +2459,17 @@ SubObjectPropertyOf(obo:RO_0002236 obo:RO_0002444)
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0002237 "A sub-relation of parasite-of in which the parasite is a plant, and the parasite is parasitic under natural conditions and is also photosynthetic to some degree. Hemiparasites may just obtain water and mineral nutrients from the host plant. Many obtain at least part of their organic nutrients from the host as well.")
 AnnotationAssertion(rdfs:label obo:RO_0002237 "hemiparasite of")
 SubObjectPropertyOf(obo:RO_0002237 obo:RO_0002444)
+
+# Object Property: obo:RO_0002238 (has component participant)
+
+AnnotationAssertion(obo:IAO_0000114 obo:RO_0002238 obo:IAO_0000428)
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0002238 "X 'has component participant' Y means X 'has participant' Y and there is a cardinality constraint that specifies the numbers of Ys.")
+AnnotationAssertion(obo:IAO_0000117 obo:RO_0002238 "Bill Duncan")
+AnnotationAssertion(obo:IAO_0000232 obo:RO_0002238 "This object property is needed for axioms using has_participant with a cardinality contrainsts; e.g., has_particpant min 2 object. However, OWL does not permit cardinality constrains with object properties that have property chains (like has_particant) or are transitive (like has_part).
+
+If you need an axiom that says 'has_participant min 2 object', you should instead say 'has_component_participant min 2 object'.")
+AnnotationAssertion(rdfs:label obo:RO_0002238 "has component participant"@en)
+SubObjectPropertyOf(obo:RO_0002238 obo:RO_0000057)
 
 # Object Property: obo:RO_0002240 (has exposure receptor)
 


### PR DESCRIPTION
Fixes #489 

This property is a "fake" OP that is used for cases in which `has participant` has a cardinality constraint. 

This ticket arose out of issues in ENVO. See ENVO tickets:  
https://github.com/EnvironmentOntology/envo/issues/1182   
https://github.com/EnvironmentOntology/envo/issues/1072

@cmungall I used your id range.