### PR TITLE
Issue 497: add utilizes relation

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -6161,7 +6161,7 @@ SubObjectPropertyOf(obo:RO_HOM0000003 obo:RO_0002320)
 # Object Property: :RO_0017001 (utilizes)
 
 AnnotationAssertion(obo:IAO_0000112 :RO_0017001 "A diagnostic testing device utilizes a specimen.")
-AnnotationAssertion(obo:IAO_0000115 :RO_0017001 "X utilizes Y means X and Y are material entities, and X is capalble of some process P that has input Y.")
+AnnotationAssertion(obo:IAO_0000115 :RO_0017001 "X utilizes Y means X and Y are material entities, and X is capable of some process P that has input Y.")
 AnnotationAssertion(obo:IAO_0000117 :RO_0017001 "Asiyah Lin")
 AnnotationAssertion(obo:IAO_0000117 :RO_0017001 "Bill Duncan (https://orcid.org/0000-0001-9625-1899)")
 AnnotationAssertion(obo:IAO_0000232 :RO_0017001 "A diagnostic testing device utilizes a specimen means that the diagnostic testing device is capable of an assay, and this assay a specimen as its input.")

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -2472,7 +2472,6 @@ SubObjectPropertyOf(obo:RO_0002237 obo:RO_0002444)
 
 # Object Property: obo:RO_0002238 (has component participant)
 
-AnnotationAssertion(obo:IAO_0000114 obo:RO_0002238 obo:IAO_0000428)
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0002238 "X 'has component participant' Y means X 'has participant' Y and there is a cardinality constraint that specifies the numbers of Ys.")
 AnnotationAssertion(obo:IAO_0000117 obo:RO_0002238 "Bill Duncan")
 AnnotationAssertion(obo:IAO_0000232 obo:RO_0002238 "This object property is needed for axioms using has_participant with a cardinality contrainsts; e.g., has_particpant min 2 object. However, OWL does not permit cardinality constrains with object properties that have property chains (like has_particant) or are transitive (like has_part).

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -541,6 +541,7 @@ Declaration(ObjectProperty(obo:RO_0015002))
 Declaration(ObjectProperty(obo:RO_0015003))
 Declaration(ObjectProperty(obo:RO_0040035))
 Declaration(ObjectProperty(obo:RO_0040036))
+Declaration(ObjectProperty(:RO_0017001))
 Declaration(DataProperty(obo:RO_0002029))
 Declaration(AnnotationProperty(obo:IAO_0000232))
 Declaration(AnnotationProperty(obo:IAO_0000589))
@@ -6157,6 +6158,17 @@ SubObjectPropertyOf(obo:RO_HOM0000001 obo:RO_0002158)
 
 SubObjectPropertyOf(obo:RO_HOM0000003 obo:RO_0002320)
 
+# Object Property: :RO_0017001 (utilizes)
+
+AnnotationAssertion(obo:IAO_0000112 :RO_0017001 "A diagnostic testing device utilizes a specimen.")
+AnnotationAssertion(obo:IAO_0000115 :RO_0017001 "X utilizes Y means X and Y are material entities, and X is capalble of some process P that has input Y.")
+AnnotationAssertion(obo:IAO_0000117 :RO_0017001 "Asiyah Lin")
+AnnotationAssertion(obo:IAO_0000117 :RO_0017001 "Bill Duncan (https://orcid.org/0000-0001-9625-1899)")
+AnnotationAssertion(obo:IAO_0000232 :RO_0017001 "A diagnostic testing device utilizes a specimen means that the diagnostic testing device is capable of an assay, and this assay a specimen as its input.")
+AnnotationAssertion(obo:IAO_0000232 :RO_0017001 "See github ticket https://github.com/oborel/obo-relations/issues/497")
+AnnotationAssertion(oboInOwl:creation_date :RO_0017001 "2021-11-08")
+AnnotationAssertion(rdfs:label :RO_0017001 "utilizes"@en)
+
 
 ############################
 #   Data Properties
@@ -6297,6 +6309,7 @@ SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002162) obo:RO_00
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002211) obo:RO_0002596)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002212) obo:RO_0002597)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002213) obo:RO_0002598)
+SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002233) :RO_0017001)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002481 obo:RO_0002400) obo:RO_0002447)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002482 obo:RO_0002400) obo:RO_0002480)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002224 obo:BFO_0000066) obo:RO_0002231)

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -2474,7 +2474,7 @@ SubObjectPropertyOf(obo:RO_0002237 obo:RO_0002444)
 # Object Property: obo:RO_0002238 (has component participant)
 
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0002238 "X 'has component participant' Y means X 'has participant' Y and there is a cardinality constraint that specifies the numbers of Ys.")
-AnnotationAssertion(obo:IAO_0000117 obo:RO_0002238 "Bill Duncan")
+AnnotationAssertion(obo:IAO_0000117 obo:RO_0002238 "Bill Duncan (https://orcid.org/0000-0001-9625-1899)")
 AnnotationAssertion(obo:IAO_0000232 obo:RO_0002238 "This object property is needed for axioms using has_participant with a cardinality contrainsts; e.g., has_particpant min 2 object. However, OWL does not permit cardinality constrains with object properties that have property chains (like has_particant) or are transitive (like has_part).
 
 If you need an axiom that says 'has_participant min 2 object', you should instead say 'has_component_participant min 2 object'.")

--- a/src/ontology/ro-idranges.owl
+++ b/src/ontology/ro-idranges.owl
@@ -83,3 +83,7 @@ EquivalentTo: xsd:integer[> 15001 , <= 16000]
 Datatype: idrange:18
 Annotations: allocatedto: "Lauren Chan"
 EquivalentTo: xsd:integer[> 16001 , <= 17000]
+
+Datatype: idrange:19
+Annotations: allocatedto: "Bill Duncan"
+EquivalentTo: xsd:integer[> 17001 , <= 18000]

--- a/src/ontology/ro-idranges.owl
+++ b/src/ontology/ro-idranges.owl
@@ -86,4 +86,4 @@ EquivalentTo: xsd:integer[> 16001 , <= 17000]
 
 Datatype: idrange:19
 Annotations: allocatedto: "Bill Duncan"
-EquivalentTo: xsd:integer[> 17001 , <= 18000]
+EquivalentTo: xsd:integer[> 17000 , <= 18000]


### PR DESCRIPTION
Fixes #497 

Added the `utilizes` relation, which is defined as:
```
X utilizes Y means X and Y are material entities, and X is capable of some process P that has input Y.
```
I also performed some other clean up on the `has component participant` relation that I add a bit ago.

@linikujp Can you please review the definition and usage example.