### PR TITLE
Fix dc:license 

### DIFF
--- a/src/ontology/core.owl
+++ b/src/ontology/core.owl
@@ -80,9 +80,9 @@
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/license -->
+    <!-- http://purl.org/dc/terms/license -->
 
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/license"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/license"/>
     
 
 


### PR DESCRIPTION
http://purl.org/dc/elements/1.1/license to http://purl.org/dc/terms/license
Fixes #536 