### PR TITLE
fix IRI for utilizes

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -543,9 +543,9 @@ Declaration(ObjectProperty(obo:RO_0015002))
 Declaration(ObjectProperty(obo:RO_0015003))
 Declaration(ObjectProperty(obo:RO_0016001))
 Declaration(ObjectProperty(obo:RO_0016002))
+Declaration(ObjectProperty(obo:RO_0017001))
 Declaration(ObjectProperty(obo:RO_0040035))
 Declaration(ObjectProperty(obo:RO_0040036))
-Declaration(ObjectProperty(:RO_0017001))
 Declaration(DataProperty(obo:RO_0002029))
 Declaration(AnnotationProperty(obo:IAO_0000232))
 Declaration(AnnotationProperty(obo:IAO_0000589))
@@ -5671,15 +5671,15 @@ SubObjectPropertyOf(obo:RO_0004047 obo:RO_0002418)
 # Object Property: obo:RO_0007000 (has driver)
 
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0007000 "A relation between two entities, in which one of the entities is any natural or human-influenced factor that directly or indirectly causes a change in the other entity.")
-AnnotationAssertion(rdfs:label obo:RO_0007000 "has driver")
 AnnotationAssertion(dc:contributor obo:RO_0007000 <https://orcid.org/0000-0001-8910-9851>)
+AnnotationAssertion(rdfs:label obo:RO_0007000 "has driver")
 AnnotationAssertion(rdfs:seeAlso obo:RO_0007000 <https://github.com/oborel/obo-relations/issues/506>)
 
 # Object Property: obo:RO_0007001 (has disease driver)
 
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0007001 "A relation between an entity and a disease of a host, in which the entity is not part of the host itself, and the condition results in pathological processes.")
-AnnotationAssertion(rdfs:label obo:RO_0007001 "has disease driver")
 AnnotationAssertion(dc:contributor obo:RO_0007001 <https://orcid.org/0000-0001-8910-9851>)
+AnnotationAssertion(rdfs:label obo:RO_0007001 "has disease driver")
 AnnotationAssertion(rdfs:seeAlso obo:RO_0007001 <https://github.com/oborel/obo-relations/issues/506>)
 SubObjectPropertyOf(obo:RO_0007001 obo:RO_0007000)
 
@@ -6184,6 +6184,17 @@ AnnotationAssertion(rdfs:label obo:RO_0016002 "has disease")
 AnnotationAssertion(rdfs:seeAlso obo:RO_0016002 "https://github.com/oborel/obo-relations/issues/478")
 SubObjectPropertyOf(obo:RO_0016002 obo:RO_0016001)
 
+# Object Property: obo:RO_0017001 (utilizes)
+
+AnnotationAssertion(obo:IAO_0000112 obo:RO_0017001 "A diagnostic testing device utilizes a specimen.")
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0017001 "X utilizes Y means X and Y are material entities, and X is capable of some process P that has input Y.")
+AnnotationAssertion(obo:IAO_0000117 obo:RO_0017001 "Asiyah Lin")
+AnnotationAssertion(obo:IAO_0000117 obo:RO_0017001 "https://orcid.org/0000-0001-9625-1899 Bill Duncan")
+AnnotationAssertion(obo:IAO_0000232 obo:RO_0017001 "A diagnostic testing device utilizes a specimen means that the diagnostic testing device is capable of an assay, and this assay a specimen as its input.")
+AnnotationAssertion(obo:IAO_0000232 obo:RO_0017001 "See github ticket https://github.com/oborel/obo-relations/issues/497")
+AnnotationAssertion(oboInOwl:creation_date obo:RO_0017001 "2021-11-08")
+AnnotationAssertion(rdfs:label obo:RO_0017001 "utilizes"@en)
+
 # Object Property: obo:RO_0040035 (disease relationship)
 
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0040035 "This relation groups  relations between diseases and any other kind of entity.")
@@ -6213,17 +6224,6 @@ SubObjectPropertyOf(obo:RO_HOM0000001 obo:RO_0002158)
 # Object Property: obo:RO_HOM0000003 (in homocracy relationship with)
 
 SubObjectPropertyOf(obo:RO_HOM0000003 obo:RO_0002320)
-
-# Object Property: :RO_0017001 (utilizes)
-
-AnnotationAssertion(obo:IAO_0000112 :RO_0017001 "A diagnostic testing device utilizes a specimen.")
-AnnotationAssertion(obo:IAO_0000115 :RO_0017001 "X utilizes Y means X and Y are material entities, and X is capable of some process P that has input Y.")
-AnnotationAssertion(obo:IAO_0000117 :RO_0017001 "Asiyah Lin")
-AnnotationAssertion(obo:IAO_0000117 :RO_0017001 "Bill Duncan (https://orcid.org/0000-0001-9625-1899)")
-AnnotationAssertion(obo:IAO_0000232 :RO_0017001 "A diagnostic testing device utilizes a specimen means that the diagnostic testing device is capable of an assay, and this assay a specimen as its input.")
-AnnotationAssertion(obo:IAO_0000232 :RO_0017001 "See github ticket https://github.com/oborel/obo-relations/issues/497")
-AnnotationAssertion(oboInOwl:creation_date :RO_0017001 "2021-11-08")
-AnnotationAssertion(rdfs:label :RO_0017001 "utilizes"@en)
 
 
 ############################
@@ -6365,7 +6365,7 @@ SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002162) obo:RO_00
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002211) obo:RO_0002596)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002212) obo:RO_0002597)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002213) obo:RO_0002598)
-SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002233) :RO_0017001)
+SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002233) obo:RO_0017001)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002481 obo:RO_0002400) obo:RO_0002447)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002215 obo:RO_0002482 obo:RO_0002400) obo:RO_0002480)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002224 obo:BFO_0000066) obo:RO_0002231)


### PR DESCRIPTION
Fixes #547 
Removed the `ro.owl` part from the IRI for `utilizes`. The IRI is now:  
http://purl.obolibrary.org/obo/RO_0017001