### PR TITLE
Fix expansion of never_in_taxon to use correct syntax.

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -654,7 +654,7 @@ AnnotationAssertion(obo:IAO_0000115 obo:RO_0002161 "x never in taxon T if and on
 AnnotationAssertion(obo:IAO_0000117 obo:RO_0002161 "Chris Mungall"@en)
 AnnotationAssertion(obo:IAO_0000119 obo:RO_0002161 <http://www.ncbi.nlm.nih.gov/pubmed/17921072>)
 AnnotationAssertion(obo:IAO_0000119 obo:RO_0002161 <http://www.ncbi.nlm.nih.gov/pubmed/20973947>)
-AnnotationAssertion(obo:IAO_0000425 obo:RO_0002161 "?X DisjointWith RO_0002162 some ?Y ")
+AnnotationAssertion(obo:IAO_0000425 obo:RO_0002161 "Class: ?X DisjointWith: RO_0002162 some ?Y ")
 AnnotationAssertion(rdfs:label obo:RO_0002161 "never in taxon"^^xsd:string)
 AnnotationAssertion(rdfs:seeAlso obo:RO_0002161 <https://github.com/obophenotype/uberon/wiki/Taxon-constraints>)
 SubAnnotationPropertyOf(obo:RO_0002161 obo:RO_0002172)


### PR DESCRIPTION
The `never_in_taxon` (RO_0002161) macro expands to an invalid syntax that is not recognized and therefore ignored by owltools --expand-macros.

This patch fixes the expansion to use a valid Manchester syntax as expected by owltools.

closes #546