### PR TITLE
Remove deprecated inverse assertion

### DIFF
--- a/src/ontology/core.owl
+++ b/src/ontology/core.owl
@@ -606,7 +606,6 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <!-- http://purl.obolibrary.org/obo/RO_0004096 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0004096">
-        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0004097"/>
         <rdfs:comment>DEPRECATED This relation is similar to but different in important respects to the characteristic-of relation. See comments on that relation for more information.</rdfs:comment>
         <rdfs:label xml:lang="en">DEPRECATED inheres in</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>


### PR DESCRIPTION
on the old bearer of relation (since deprecated).

This is flagged by the OBO dashboard report.