### PR TITLE
Fix datetime format for recently added term. 

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -6261,7 +6261,7 @@ AnnotationAssertion(obo:IAO_0000117 obo:RO_0017001 "Asiyah Lin")
 AnnotationAssertion(obo:IAO_0000117 obo:RO_0017001 "https://orcid.org/0000-0001-9625-1899 Bill Duncan")
 AnnotationAssertion(obo:IAO_0000232 obo:RO_0017001 "A diagnostic testing device utilizes a specimen means that the diagnostic testing device is capable of an assay, and this assay a specimen as its input.")
 AnnotationAssertion(obo:IAO_0000232 obo:RO_0017001 "See github ticket https://github.com/oborel/obo-relations/issues/497")
-AnnotationAssertion(oboInOwl:creation_date obo:RO_0017001 "2021-11-08")
+AnnotationAssertion(oboInOwl:creation_date obo:RO_0017001 "2021-11-08T12:00:00Z")
 AnnotationAssertion(rdfs:label obo:RO_0017001 "utilizes"@en)
 
 # Object Property: obo:RO_0019000 (regulates characteristic)


### PR DESCRIPTION
Required for OBO-Edit OBO parser.

Related to #511.