### PR TITLE
Remove some unused GO terms, one of which is obsolete in GO.

### DIFF
--- a/src/ontology/go_cc_import.owl
+++ b/src/ontology/go_cc_import.owl
@@ -100,17 +100,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GO_0042734 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0042734">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0016020"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044456"/>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/go.owl"/>
-        <rdfs:label xml:lang="en">presynaptic membrane</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GO_0042995 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0042995">
@@ -130,32 +119,12 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GO_0044456 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044456">
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/go.owl"/>
-        <rdfs:label xml:lang="en">synapse part</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GO_0045202 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0045202">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CARO_0000003"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/go.owl"/>
         <rdfs:label xml:lang="en">synapse</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GO_0045211 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0045211">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0016020"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044456"/>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/go.owl"/>
-        <rdfs:label xml:lang="en">postsynaptic membrane</rdfs:label>
     </owl:Class>
 </rdf:RDF>
 


### PR DESCRIPTION
Fixes #530.

I deleted 'synapse part' and its subclasses 'presynaptic membrane' and 'postsynaptic membrane'. None of them had any usages in axioms. I didn't see any automated way to regenerate the go_cc_import.owl.