### PR TITLE
Make overlaps symmetric

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -1857,6 +1857,7 @@ AnnotationAssertion(oboInOwl:inSubset obo:RO_0002131 obo:valid_for_gocam)
 AnnotationAssertion(oboInOwl:inSubset obo:RO_0002131 subsets:ro-eco)
 AnnotationAssertion(rdfs:label obo:RO_0002131 "overlaps"@en)
 SubObjectPropertyOf(obo:RO_0002131 obo:RO_0002323)
+SymmetricObjectProperty(obo:RO_0002131)
 
 # Object Property: obo:RO_0002132 (has fasciculating neuron projection)
 


### PR DESCRIPTION
fix #580 

I tried looking very far back in time, and I cannot find any evidence of overlaps ever being symmetric..

Is there any ontology that has plenty of overlaps relations to test this with?

cc @dosumis who I think uses overlaps a lot