### PR TITLE
Clean up ro-metamodel.yaml

### DIFF
--- a/src/patterns/ro-interaction-relations-src.yaml
+++ b/src/patterns/ro-interaction-relations-src.yaml
@@ -1,4 +1,3 @@
-
 # NOTE: this one exists in RO
 #  merging it in now will create conflicting defs, figure out pipeline later
 
@@ -42,4 +41,3 @@
     rolification_of: GO:0019107
     contributor: orcid:0000-0003-4423-4370
   process_to_object_property: RO:0002400   ## has direct input
-

--- a/src/patterns/ro-interaction-relations.ofn
+++ b/src/patterns/ro-interaction-relations.ofn
@@ -21,7 +21,7 @@ Prefix( orcid: = <https://orcid.org/> )
 
 Ontology( <http://purl.obolibrary.org/obo/ro/ro-metamodel.yaml>
     SubObjectPropertyOf( <http://purl.obolibrary.org/obo/RO_0018001> <http://purl.obolibrary.org/obo/RO_0002564> )
-    AnnotationAssertion( <http://purl.obolibrary.org/obo/IAO_00000115> <http://purl.obolibrary.org/obo/RO_0018001> "Helper relation for OWL definition of RO:0018002 myristoylates" )
+    AnnotationAssertion( <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/RO_0018001> "Helper relation for OWL definition of RO:0018002 myristoylates" )
     SubObjectPropertyOf(     ObjectPropertyChain(
         <http://purl.obolibrary.org/obo/RO_0002215>
         <http://purl.obolibrary.org/obo/RO_0018001>

--- a/src/patterns/ro-interaction-relations.owl
+++ b/src/patterns/ro-interaction-relations.owl
@@ -23,12 +23,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_00000115 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_00000115"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -86,7 +80,7 @@
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0018001">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002564"/>
-        <obo:IAO_00000115>Helper relation for OWL definition of RO:0018002 myristoylates</obo:IAO_00000115>
+        <obo:IAO_0000115>Helper relation for OWL definition of RO:0018002 myristoylates</obo:IAO_0000115>
         <terms:contributor rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
         <rdfs:label>is myristoyltransferase activity</rdfs:label>
     </owl:ObjectProperty>

--- a/src/patterns/ro-metamodel.yaml
+++ b/src/patterns/ro-metamodel.yaml
@@ -300,7 +300,7 @@ classes:
     is_a: Class
   Subset:
     is_a: AnnotationProperty
-    class_uri: oio:Subset
+    class_uri: OIO:Subset
     description: A grouping for ontology terms
   Property:
     is_a: NamedThing


### PR DESCRIPTION
This PR fixes the casing in one instance of `OIO` and reruns make. For some reason there were extra zeros in the IAO local ids