### PR TITLE
Adding "surface of" alt label

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -1275,6 +1275,7 @@ AnnotationAssertion(oboInOwl:inSubset obo:RO_0001025 obo:valid_for_go_gp2term)
 
 # Object Property: obo:RO_0002000 (2D boundary of)
 
+AnnotationAssertion(obo:IAO_0000118 obo:RO_0002000 "surface of"@en)
 SubObjectPropertyOf(obo:RO_0002000 obo:RO_0002323)
 
 # Object Property: obo:RO_0002001 (aligned with)


### PR DESCRIPTION
Adding "surface of" as alternative to "2D boundary of".

This is to support https://github.com/oborel/obo-relations/issues/509 