### PR TITLE
Remove axiom

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -26,12 +26,11 @@ Import(<http://purl.obolibrary.org/obo/ro/generated-axioms.owl>)
 Import(<http://purl.obolibrary.org/obo/ro/go-biotic.owl>)
 Import(<http://purl.obolibrary.org/obo/ro/go_cc_import.owl>)
 Import(<http://purl.obolibrary.org/obo/ro/go_mf_import.owl>)
+Import(<http://purl.obolibrary.org/obo/ro/omo_import.owl>)
 Import(<http://purl.obolibrary.org/obo/ro/other_import.owl>)
 Import(<http://purl.obolibrary.org/obo/ro/pato_import.owl>)
 Import(<http://purl.obolibrary.org/obo/ro/rohom.owl>)
 Import(<http://purl.obolibrary.org/obo/ro/temporal-intervals.owl>)
-Import(<http://purl.obolibrary.org/obo/ro/omo_import.owl>)
-
 Annotation(dce:description "The OBO Relations Ontology (RO) is a collection of OWL relations (ObjectProperties) intended for use across a wide variety of biological ontologies."@en)
 Annotation(dce:title "OBO Relations Ontology"@en)
 Annotation(dc:license <https://creativecommons.org/publicdomain/zero/1.0/>)
@@ -1997,9 +1996,9 @@ AnnotationAssertion(obo:RO_0001900 obo:RO_0002150 obo:RO_0001901)
 AnnotationAssertion(rdfs:label obo:RO_0002150 "continuous with"@en)
 AnnotationAssertion(rdfs:seeAlso obo:RO_0002150 "FMA:85972")
 SubObjectPropertyOf(obo:RO_0002150 obo:RO_0002323)
+SymmetricObjectProperty(obo:RO_0002150)
 ObjectPropertyDomain(obo:RO_0002150 obo:BFO_0000004)
 ObjectPropertyRange(obo:RO_0002150 obo:BFO_0000004)
-SymmetricObjectProperty(obo:RO_0002150)
 
 # Object Property: obo:RO_0002151 (partially overlaps)
 
@@ -6488,10 +6487,6 @@ SubClassOf(obo:BFO_0000003 ObjectAllValuesFrom(obo:RO_HOM0000000 obo:BFO_0000003
 # Class: obo:BFO_0000015 (process)
 
 SubClassOf(obo:BFO_0000015 ObjectAllValuesFrom(obo:RO_0002214 obo:BFO_0000015))
-
-# Class: obo:CARO_0000006 (material anatomical entity)
-
-SubClassOf(obo:CARO_0000006 ObjectAllValuesFrom(obo:RO_0002179 obo:CARO_0000003))
 
 # Class: obo:CHEBI_50906 (obo:CHEBI_50906)
 


### PR DESCRIPTION
Remove axiom `drains only 'connected anatomical structure'` asserted for [CARO:0000006 'material anatomical entity'](https://www.ebi.ac.uk/ols/ontologies/caro/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCARO_0000006)).

If applied, this commit will fix #623.