### PR TITLE
NTR: Add 3 pharmacological relations for small molecules

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -562,8 +562,8 @@ Declaration(ObjectProperty(obo:RO_0018001))
 Declaration(ObjectProperty(obo:RO_0018002))
 Declaration(ObjectProperty(obo:RO_0018003))
 Declaration(ObjectProperty(obo:RO_0018027))
+Declaration(ObjectProperty(obo:RO_0018028))
 Declaration(ObjectProperty(obo:RO_0018029))
-Declaration(ObjectProperty(obo:RO_0018030))
 Declaration(ObjectProperty(obo:RO_0019000))
 Declaration(ObjectProperty(obo:RO_0019001))
 Declaration(ObjectProperty(obo:RO_0019002))
@@ -6407,6 +6407,15 @@ AnnotationAssertion(rdfs:label obo:RO_0018027 "is agonist of")
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018027 <https://www.wikidata.org/wiki/Property:P3772>)
 SubObjectPropertyOf(obo:RO_0018027 obo:RO_0002450)
 
+# Object Property: obo:RO_0018028 (is inverse agonist of)
+
+AnnotationAssertion(obo:IAO_0000112 obo:RO_0018028 "pimavanserin (CHEBI:133017) is inverse agonist of HTR2A (PR:P28223)")
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0018028 "a relation between a ligand (material entity) and a receptor (material entity) that implies the binding of the ligand to the receptor inhibits some activity of the receptor to below basal level")
+AnnotationAssertion(dce:creator obo:RO_0018028 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(rdfs:label obo:RO_0018028 "is inverse agonist of")
+AnnotationAssertion(rdfs:seeAlso obo:RO_0018028 <https://www.wikidata.org/wiki/Property:P9275>)
+SubObjectPropertyOf(obo:RO_0018028 obo:RO_0002449)
+
 # Object Property: obo:RO_0018029 (is antagonist of)
 
 AnnotationAssertion(obo:IAO_0000112 obo:RO_0018029 "tretinoin (CHEBI:15367) is antagonist of Nuclear receptor ROR-beta (PR:Q92753)")
@@ -6415,15 +6424,6 @@ AnnotationAssertion(dce:creator obo:RO_0018029 <https://orcid.org/0000-0003-4423
 AnnotationAssertion(rdfs:label obo:RO_0018029 "is antagonist of")
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018029 <https://www.wikidata.org/wiki/Property:P3773>)
 SubObjectPropertyOf(obo:RO_0018029 obo:RO_0002449)
-
-# Object Property: obo:RO_0018030 (is inverse agonist of)
-
-AnnotationAssertion(obo:IAO_0000112 obo:RO_0018030 "pimavanserin (CHEBI:133017) is inverse agonist of HTR2A (PR:P28223)")
-AnnotationAssertion(obo:IAO_0000115 obo:RO_0018030 "a relation between a ligand (material entity) and a receptor (material entity) that implies the binding of the ligand to the receptor inhibits some activity of the receptor to below basal level")
-AnnotationAssertion(dce:creator obo:RO_0018030 <https://orcid.org/0000-0003-4423-4370>)
-AnnotationAssertion(rdfs:label obo:RO_0018030 "is inverse agonist of")
-AnnotationAssertion(rdfs:seeAlso obo:RO_0018030 <https://www.wikidata.org/wiki/Property:P9275>)
-SubObjectPropertyOf(obo:RO_0018030 obo:RO_0002449)
 
 # Object Property: obo:RO_0019000 (regulates characteristic)
 

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -562,12 +562,8 @@ Declaration(ObjectProperty(obo:RO_0018001))
 Declaration(ObjectProperty(obo:RO_0018002))
 Declaration(ObjectProperty(obo:RO_0018003))
 Declaration(ObjectProperty(obo:RO_0018027))
-Declaration(ObjectProperty(obo:RO_0018028))
 Declaration(ObjectProperty(obo:RO_0018029))
 Declaration(ObjectProperty(obo:RO_0018030))
-Declaration(ObjectProperty(obo:RO_0018031))
-Declaration(ObjectProperty(obo:RO_0018032))
-Declaration(ObjectProperty(obo:RO_0018033))
 Declaration(ObjectProperty(obo:RO_0019000))
 Declaration(ObjectProperty(obo:RO_0019001))
 Declaration(ObjectProperty(obo:RO_0019002))
@@ -1535,7 +1531,6 @@ AnnotationAssertion(oboInOwl:created_by obo:RO_0002019 "dos"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:RO_0002019 "2017-07-19T17:30:36Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:RO_0002019 "has ligand")
 SubObjectPropertyOf(obo:RO_0002019 obo:RO_0002233)
-InverseObjectProperties(obo:RO_0002019 obo:RO_0018028)
 
 # Object Property: obo:RO_0002020 (transports)
 
@@ -6405,55 +6400,30 @@ AnnotationAssertion(rdfs:label obo:RO_0018003 "myristoylated by")
 
 # Object Property: obo:RO_0018027 (is agonist of)
 
-AnnotationAssertion(obo:IAO_0000115 obo:RO_0018027 "a relation between a continuant and a receptor activity, in which the continuant is a small molecule that acts as an agonist to the receptor")
+AnnotationAssertion(obo:IAO_0000112 obo:RO_0018027 "mibolerone (CHEBI:34849) is agonist of androgen receptor (PR:P10275)")
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0018027 "a relation between a ligand (material entity) and a receptor (material entity) that implies the binding of the ligand to the receptor activates some activity of the receptor")
 AnnotationAssertion(dce:creator obo:RO_0018027 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(rdfs:label obo:RO_0018027 "is agonist of")
-SubObjectPropertyOf(obo:RO_0018027 obo:RO_0012005)
-SubObjectPropertyOf(obo:RO_0018027 obo:RO_0018028)
-InverseObjectProperties(obo:RO_0018027 obo:RO_0018031)
-
-# Object Property: obo:RO_0018028 (is ligand)
-
-AnnotationAssertion(obo:IAO_0000115 obo:RO_0018028 "A relationship that holds between between a chemical entity, typically a small molecule or peptide, and a receptor that carries information between cells or compartments of a cell and which binds the receptor and regulates its effector function.")
-AnnotationAssertion(dce:creator obo:RO_0018028 <https://orcid.org/0000-0003-4423-4370>)
-AnnotationAssertion(rdfs:label obo:RO_0018028 "is ligand")
-SubObjectPropertyOf(obo:RO_0018028 obo:RO_0002352)
+AnnotationAssertion(rdfs:seeAlso obo:RO_0018027 <https://www.wikidata.org/wiki/Property:P3772>)
+SubObjectPropertyOf(obo:RO_0018027 obo:RO_0002450)
 
 # Object Property: obo:RO_0018029 (is antagonist of)
 
-AnnotationAssertion(obo:IAO_0000115 obo:RO_0018029 "a relation between a continuant and a receptor activity, in which the continuant is a small molecule that inhibits the receptor")
+AnnotationAssertion(obo:IAO_0000112 obo:RO_0018029 "tretinoin (CHEBI:15367) is antagonist of Nuclear receptor ROR-beta (PR:Q92753)")
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0018029 "a relation between a ligand (material entity) and a receptor (material entity) that implies the binding of the ligand to the receptor reduces some activity of the receptor to basal level")
 AnnotationAssertion(dce:creator obo:RO_0018029 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(rdfs:label obo:RO_0018029 "is antagonist of")
-SubObjectPropertyOf(obo:RO_0018029 obo:RO_0012006)
-SubObjectPropertyOf(obo:RO_0018029 obo:RO_0018028)
-InverseObjectProperties(obo:RO_0018029 obo:RO_0018032)
+AnnotationAssertion(rdfs:seeAlso obo:RO_0018029 <https://www.wikidata.org/wiki/Property:P3773>)
+SubObjectPropertyOf(obo:RO_0018029 obo:RO_0002449)
 
 # Object Property: obo:RO_0018030 (is inverse agonist of)
 
+AnnotationAssertion(obo:IAO_0000112 obo:RO_0018030 "pimavanserin (CHEBI:133017) is inverse agonist of HTR2A (PR:P28223)")
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0018030 "a relation between a ligand (material entity) and a receptor (material entity) that implies the binding of the ligand to the receptor inhibits some activity of the receptor to below basal level")
 AnnotationAssertion(dce:creator obo:RO_0018030 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(rdfs:label obo:RO_0018030 "is inverse agonist of")
-SubObjectPropertyOf(obo:RO_0018030 obo:RO_0018028)
-InverseObjectProperties(obo:RO_0018030 obo:RO_0018033)
-
-# Object Property: obo:RO_0018031 (has agonist)
-
-AnnotationAssertion(dce:creator obo:RO_0018031 <https://orcid.org/0000-0003-4423-4370>)
-AnnotationAssertion(rdfs:label obo:RO_0018031 "has agonist")
-SubObjectPropertyOf(obo:RO_0018031 obo:RO_0002019)
-SubObjectPropertyOf(obo:RO_0018031 obo:RO_0012001)
-
-# Object Property: obo:RO_0018032 (has antagonist)
-
-AnnotationAssertion(dce:creator obo:RO_0018032 <https://orcid.org/0000-0003-4423-4370>)
-AnnotationAssertion(rdfs:label obo:RO_0018032 "has antagonist")
-SubObjectPropertyOf(obo:RO_0018032 obo:RO_0002019)
-SubObjectPropertyOf(obo:RO_0018032 obo:RO_0012002)
-
-# Object Property: obo:RO_0018033 (has inverse agonist)
-
-AnnotationAssertion(dce:creator obo:RO_0018033 <https://orcid.org/0000-0003-4423-4370>)
-AnnotationAssertion(rdfs:label obo:RO_0018033 "has inverse agonist")
-SubObjectPropertyOf(obo:RO_0018033 obo:RO_0002019)
+AnnotationAssertion(rdfs:seeAlso obo:RO_0018030 <https://www.wikidata.org/wiki/Property:P9275>)
+SubObjectPropertyOf(obo:RO_0018030 obo:RO_0002449)
 
 # Object Property: obo:RO_0019000 (regulates characteristic)
 

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -561,6 +561,10 @@ Declaration(ObjectProperty(obo:RO_0017001))
 Declaration(ObjectProperty(obo:RO_0018001))
 Declaration(ObjectProperty(obo:RO_0018002))
 Declaration(ObjectProperty(obo:RO_0018003))
+Declaration(ObjectProperty(obo:RO_0018027))
+Declaration(ObjectProperty(obo:RO_0018028))
+Declaration(ObjectProperty(obo:RO_0018029))
+Declaration(ObjectProperty(obo:RO_0018030))
 Declaration(ObjectProperty(obo:RO_0019000))
 Declaration(ObjectProperty(obo:RO_0019001))
 Declaration(ObjectProperty(obo:RO_0019002))
@@ -1528,6 +1532,7 @@ AnnotationAssertion(oboInOwl:created_by obo:RO_0002019 "dos"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:RO_0002019 "2017-07-19T17:30:36Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:RO_0002019 "has ligand")
 SubObjectPropertyOf(obo:RO_0002019 obo:RO_0002233)
+InverseObjectProperties(obo:RO_0002019 obo:RO_0018028)
 
 # Object Property: obo:RO_0002020 (transports)
 
@@ -6394,6 +6399,35 @@ InverseObjectProperties(obo:RO_0018002 obo:RO_0018003)
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0018003 "inverse of myristoylates")
 AnnotationAssertion(dc:contributor obo:RO_0018003 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(rdfs:label obo:RO_0018003 "myristoylated by")
+
+# Object Property: obo:RO_0018027 (is agonist of)
+
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0018027 "a relation between a continuant and a receptor activity, in which the continuant is a small molecule that acts as an agonist to the receptor")
+AnnotationAssertion(dce:creator obo:RO_0018027 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(rdfs:label obo:RO_0018027 "is agonist of")
+SubObjectPropertyOf(obo:RO_0018027 obo:RO_0012005)
+SubObjectPropertyOf(obo:RO_0018027 obo:RO_0018028)
+
+# Object Property: obo:RO_0018028 (is ligand)
+
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0018028 "A relationship that holds between between a chemical entity, typically a small molecule or peptide, and a receptor that carries information between cells or compartments of a cell and which binds the receptor and regulates its effector function.")
+AnnotationAssertion(dce:creator obo:RO_0018028 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(rdfs:label obo:RO_0018028 "is ligand")
+SubObjectPropertyOf(obo:RO_0018028 obo:RO_0002352)
+
+# Object Property: obo:RO_0018029 (is antagonist of)
+
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0018029 "a relation between a continuant and a receptor activity, in which the continuant is a small molecule that inhibits the receptor")
+AnnotationAssertion(dce:creator obo:RO_0018029 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(rdfs:label obo:RO_0018029 "is antagonist of")
+SubObjectPropertyOf(obo:RO_0018029 obo:RO_0012006)
+SubObjectPropertyOf(obo:RO_0018029 obo:RO_0018028)
+
+# Object Property: obo:RO_0018030 (is inverse agonist of)
+
+AnnotationAssertion(dce:creator obo:RO_0018030 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(rdfs:label obo:RO_0018030 "is inverse agonist of")
+SubObjectPropertyOf(obo:RO_0018030 obo:RO_0018028)
 
 # Object Property: obo:RO_0019000 (regulates characteristic)
 

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -565,6 +565,9 @@ Declaration(ObjectProperty(obo:RO_0018027))
 Declaration(ObjectProperty(obo:RO_0018028))
 Declaration(ObjectProperty(obo:RO_0018029))
 Declaration(ObjectProperty(obo:RO_0018030))
+Declaration(ObjectProperty(obo:RO_0018031))
+Declaration(ObjectProperty(obo:RO_0018032))
+Declaration(ObjectProperty(obo:RO_0018033))
 Declaration(ObjectProperty(obo:RO_0019000))
 Declaration(ObjectProperty(obo:RO_0019001))
 Declaration(ObjectProperty(obo:RO_0019002))
@@ -6407,6 +6410,7 @@ AnnotationAssertion(dce:creator obo:RO_0018027 <https://orcid.org/0000-0003-4423
 AnnotationAssertion(rdfs:label obo:RO_0018027 "is agonist of")
 SubObjectPropertyOf(obo:RO_0018027 obo:RO_0012005)
 SubObjectPropertyOf(obo:RO_0018027 obo:RO_0018028)
+InverseObjectProperties(obo:RO_0018027 obo:RO_0018031)
 
 # Object Property: obo:RO_0018028 (is ligand)
 
@@ -6422,12 +6426,34 @@ AnnotationAssertion(dce:creator obo:RO_0018029 <https://orcid.org/0000-0003-4423
 AnnotationAssertion(rdfs:label obo:RO_0018029 "is antagonist of")
 SubObjectPropertyOf(obo:RO_0018029 obo:RO_0012006)
 SubObjectPropertyOf(obo:RO_0018029 obo:RO_0018028)
+InverseObjectProperties(obo:RO_0018029 obo:RO_0018032)
 
 # Object Property: obo:RO_0018030 (is inverse agonist of)
 
 AnnotationAssertion(dce:creator obo:RO_0018030 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(rdfs:label obo:RO_0018030 "is inverse agonist of")
 SubObjectPropertyOf(obo:RO_0018030 obo:RO_0018028)
+InverseObjectProperties(obo:RO_0018030 obo:RO_0018033)
+
+# Object Property: obo:RO_0018031 (has agonist)
+
+AnnotationAssertion(dce:creator obo:RO_0018031 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(rdfs:label obo:RO_0018031 "has agonist")
+SubObjectPropertyOf(obo:RO_0018031 obo:RO_0002019)
+SubObjectPropertyOf(obo:RO_0018031 obo:RO_0012001)
+
+# Object Property: obo:RO_0018032 (has antagonist)
+
+AnnotationAssertion(dce:creator obo:RO_0018032 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(rdfs:label obo:RO_0018032 "has antagonist")
+SubObjectPropertyOf(obo:RO_0018032 obo:RO_0002019)
+SubObjectPropertyOf(obo:RO_0018032 obo:RO_0012002)
+
+# Object Property: obo:RO_0018033 (has inverse agonist)
+
+AnnotationAssertion(dce:creator obo:RO_0018033 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(rdfs:label obo:RO_0018033 "has inverse agonist")
+SubObjectPropertyOf(obo:RO_0018033 obo:RO_0002019)
 
 # Object Property: obo:RO_0019000 (regulates characteristic)
 


### PR DESCRIPTION
Closes #371

## Motivation

For ChIRO and the Chemical Roles Graph (https://github.com/chemical-roles/chemical-roles), we need more detailed relationships to describe causal interactions between chemicals (material entities) and receptors (material entity).

Existing relationships (i.e., [directly negatively regulates activity of](http://purl.obolibrary.org/obo/RO_0002449) and [directly positively regulates activity of](http://purl.obolibrary.org/obo/RO_0002450)) are not detailed enough.

See similar issue about drug-target relationships in https://github.com/oborel/obo-relations/issues/144.

## What this PR does

This PR creates 3 new properties:

| LUID | Name | Parent | Example |
|----------:|-------|--------|-------|
| 0018027 |  is agonist of | [directly positively regulates activity of](http://purl.obolibrary.org/obo/RO_0002450) | mibolerone (CHEBI:34849) is agonist of androgen receptor (PR:P10275) |
| 0018028 | is inverse agonist of | [directly negatively regulates activity of](http://purl.obolibrary.org/obo/RO_0002449) |  pimavanserin (CHEBI:133017) is inverse agonist of HTR2A (PR:P28223) |
| 0018029 | is antagonist of | [directly negatively regulates activity of](http://purl.obolibrary.org/obo/RO_0002449) | tretinoin (CHEBI:15367) is antagonist of Nuclear receptor ROR-beta (PR:Q92753) |


Big thanks to Jie, Alexander, Darren, Bill, and everyone else at the 2022-11-01 RO meeting who gave feedback and helped improve this PR.
