### PR TITLE
Add remaining 5 ChEBI relations

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -6607,6 +6607,7 @@ SymmetricObjectProperty(obo:RO_0018036)
 # Object Property: obo:RO_0018037 (is substitutent group from)
 
 AnnotationAssertion(Annotation(rdfs:seeAlso obo:CHEBI_30795) Annotation(rdfs:seeAlso obo:CHEBI_58957) obo:IAO_0000112 obo:RO_0018037 "carboxylatoacetyl group (CHEBI:58957) is substituent group from malonate(1-) (CHEBI:30795)")
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0018037 "Group A is a substituent group from Chemical B if A represents the functional part of A and includes information about where it is connected. A is not itself a chemical with a fully formed chemical graph, but is rather a partial graph with one or more connection points that can be used to attach to another chemical graph, typically as a functionalization.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018037 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018037 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018037 <http://purl.obolibrary.org/obo/chebi#is_substituent_group_from>)
@@ -6617,6 +6618,9 @@ SubObjectPropertyOf(obo:RO_0018037 obo:RO_0018030)
 # Object Property: obo:RO_0018038 (has functional parent)
 
 AnnotationAssertion(Annotation(rdfs:seeAlso obo:CHEBI_50851) Annotation(rdfs:seeAlso obo:CHEBI_50854) obo:IAO_0000112 obo:RO_0018038 "hydrocortamate hydrochloride (CHEBI:50854) has parent hydride hydrocortamate (CHEBI:50851)")
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0018038 "Chemical A has functional parent Chemical B if there is chemical transformation through which chemical B can be produced from chemical A. 
+
+For example, the relationship between a salt and a freebased compound is a \"has functional parent\" relationship.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018038 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018038 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018038 <http://purl.obolibrary.org/obo/chebi#has_functional_parent>)

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -6591,6 +6591,7 @@ TransitiveObjectProperty(obo:RO_0018034)
 
 # Object Property: obo:RO_0018036 (is tautomer of)
 
+AnnotationAssertion(obo:IAO_0000112 obo:RO_0018036 "3-carboxy-3-mercaptopropanoate (CHEBI:38707) is tautomer of 1,2-dicarboxyethanethiolate (CHEBI:38709) because 3-carboxy-3-mercaptopropanoate is deprotonated on the carboxylic acid whereas 1,2-dicarboxyethanethiolate is deprotonated on the secondary thiol.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018036 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018036 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018036 <http://purl.obolibrary.org/obo/chebi#is_tautomer_of>)
@@ -6599,7 +6600,7 @@ SubObjectPropertyOf(obo:RO_0018036 obo:RO_0018030)
 
 # Object Property: obo:RO_0018037 (is substitutent group from)
 
-AnnotationAssertion(obo:IAO_0000112 obo:RO_0018037 <>)
+AnnotationAssertion(obo:IAO_0000112 obo:RO_0018037 "carboxylatoacetyl group (CHEBI:58957) is substituent group from malonate(1-) (CHEBI:30795)")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018037 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018037 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018037 <http://purl.obolibrary.org/obo/chebi#is_substituent_group_from>)

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -6591,7 +6591,7 @@ TransitiveObjectProperty(obo:RO_0018034)
 
 # Object Property: obo:RO_0018036 (is tautomer of)
 
-AnnotationAssertion(obo:IAO_0000112 obo:RO_0018036 "3-carboxy-3-mercaptopropanoate (CHEBI:38707) is tautomer of 1,2-dicarboxyethanethiolate (CHEBI:38709) because 3-carboxy-3-mercaptopropanoate is deprotonated on the carboxylic acid whereas 1,2-dicarboxyethanethiolate is deprotonated on the secondary thiol.")
+AnnotationAssertion(Annotation(rdfs:seeAlso obo:CHEBI_38707) Annotation(rdfs:seeAlso obo:CHEBI_38709) obo:IAO_0000112 obo:RO_0018036 "3-carboxy-3-mercaptopropanoate (CHEBI:38707) is tautomer of 1,2-dicarboxyethanethiolate (CHEBI:38709) because 3-carboxy-3-mercaptopropanoate is deprotonated on the carboxylic acid whereas 1,2-dicarboxyethanethiolate is deprotonated on the secondary thiol.")
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0018036 "Two chemicals are tautomers if they can be readily interconverted.
 
 This commonly refers to prototropy in which a hydrogen's position is changed, such as between ketones and enols. This is also often observed in heterocyclic rings, e.g., ones containing nitrogens and/or have aryl functional groups containing heteroatoms.")
@@ -6605,7 +6605,7 @@ SymmetricObjectProperty(obo:RO_0018036)
 
 # Object Property: obo:RO_0018037 (is substitutent group from)
 
-AnnotationAssertion(obo:IAO_0000112 obo:RO_0018037 "carboxylatoacetyl group (CHEBI:58957) is substituent group from malonate(1-) (CHEBI:30795)")
+AnnotationAssertion(Annotation(rdfs:seeAlso obo:CHEBI_30795) Annotation(rdfs:seeAlso obo:CHEBI_58957) obo:IAO_0000112 obo:RO_0018037 "carboxylatoacetyl group (CHEBI:58957) is substituent group from malonate(1-) (CHEBI:30795)")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018037 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018037 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018037 <http://purl.obolibrary.org/obo/chebi#is_substituent_group_from>)
@@ -6614,7 +6614,7 @@ SubObjectPropertyOf(obo:RO_0018037 obo:RO_0018030)
 
 # Object Property: obo:RO_0018038 (has functional parent)
 
-AnnotationAssertion(obo:IAO_0000112 obo:RO_0018038 "hydrocortamate hydrochloride (CHEBI:50854) has parent hydride hydrocortamate (CHEBI:50851)")
+AnnotationAssertion(Annotation(rdfs:seeAlso obo:CHEBI_50851) Annotation(rdfs:seeAlso obo:CHEBI_50854) obo:IAO_0000112 obo:RO_0018038 "hydrocortamate hydrochloride (CHEBI:50854) has parent hydride hydrocortamate (CHEBI:50851)")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018038 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018038 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018038 <http://purl.obolibrary.org/obo/chebi#has_functional_parent>)
@@ -6623,17 +6623,22 @@ SubObjectPropertyOf(obo:RO_0018038 obo:RO_0018030)
 
 # Object Property: obo:RO_0018039 (is enantiomer of)
 
-AnnotationAssertion(obo:IAO_0000118 obo:RO_0018039 "dexmedetomidine hydrochloride (CHEBI:31472) is enantiomer of levomedetomidine hydrochloride (CHEBI:48557) because the stereochemistry of the central chiral carbon is swapped.")
+AnnotationAssertion(Annotation(rdfs:comment obo:CHEBI_48557) Annotation(rdfs:seeAlso obo:CHEBI_31472) obo:IAO_0000112 obo:RO_0018039 "dexmedetomidine hydrochloride (CHEBI:31472) is enantiomer of levomedetomidine hydrochloride (CHEBI:48557) because the stereochemistry of the central chiral carbon is swapped.")
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0018039 "Chemicals A and B are enantiomers if they share the same molecular graph except the change of the configuration of substituents around exactly one chiral center.
+
+A chemical with no chiral centers can not have an enantiomer. A chemical with multiple chiral centers can have multiple enantiomers, but its enantiomers are not themselves enantiomers (they are diastereomers).")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018039 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018039 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018039 <http://purl.obolibrary.org/obo/chebi#is_enantiomer_of>)
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:RO_0018039 "is optical isomer of")
 AnnotationAssertion(rdfs:label obo:RO_0018039 "is enantiomer of"@en)
 SubObjectPropertyOf(obo:RO_0018039 obo:RO_0018030)
 SymmetricObjectProperty(obo:RO_0018039)
 
 # Object Property: obo:RO_0018040 (has parent hydride)
 
-AnnotationAssertion(obo:IAO_0000112 obo:RO_0018040 "pyranine (CHEBI:52083) has parent hydride pyrene (CHEBI:39106). Pyrene is molecule with four fused benzene rings, whereas pyranine has the same core ring structure with additional sulfates.")
+AnnotationAssertion(Annotation(rdfs:seeAlso obo:CHEBI_39106) Annotation(rdfs:seeAlso obo:CHEBI_52083) obo:IAO_0000112 obo:RO_0018040 "pyranine (CHEBI:52083) has parent hydride pyrene (CHEBI:39106). Pyrene is molecule with four fused benzene rings, whereas pyranine has the same core ring structure with additional sulfates.")
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0018040 "Chemical A has parent hydride Chemical B if there exists a molecular graphical transformation where functional groups on A are replaced with hydrogens in order to yield B.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018040 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018040 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018040 <http://purl.obolibrary.org/obo/chebi#has_parent_hydride>)

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -6598,8 +6598,10 @@ This commonly refers to prototropy in which a hydrogen's position is changed, su
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018036 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018036 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018036 <http://purl.obolibrary.org/obo/chebi#is_tautomer_of>)
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:RO_0018036 "is desmotrope of")
 AnnotationAssertion(rdfs:label obo:RO_0018036 "is tautomer of"@en)
 SubObjectPropertyOf(obo:RO_0018036 obo:RO_0018030)
+SymmetricObjectProperty(obo:RO_0018036)
 
 # Object Property: obo:RO_0018037 (is substitutent group from)
 
@@ -6627,6 +6629,7 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018039 "2023-
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018039 <http://purl.obolibrary.org/obo/chebi#is_enantiomer_of>)
 AnnotationAssertion(rdfs:label obo:RO_0018039 "is enantiomer of"@en)
 SubObjectPropertyOf(obo:RO_0018039 obo:RO_0018030)
+SymmetricObjectProperty(obo:RO_0018039)
 
 # Object Property: obo:RO_0018040 (has parent hydride)
 

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -577,6 +577,11 @@ Declaration(ObjectProperty(obo:RO_0018031))
 Declaration(ObjectProperty(obo:RO_0018032))
 Declaration(ObjectProperty(obo:RO_0018033))
 Declaration(ObjectProperty(obo:RO_0018034))
+Declaration(ObjectProperty(obo:RO_0018036))
+Declaration(ObjectProperty(obo:RO_0018037))
+Declaration(ObjectProperty(obo:RO_0018038))
+Declaration(ObjectProperty(obo:RO_0018039))
+Declaration(ObjectProperty(obo:RO_0018040))
 Declaration(ObjectProperty(obo:RO_0019000))
 Declaration(ObjectProperty(obo:RO_0019001))
 Declaration(ObjectProperty(obo:RO_0019002))
@@ -683,6 +688,10 @@ Declaration(AnnotationProperty(skos:closeMatch))
 ############################
 #   Annotation Properties
 ############################
+
+# Annotation Property: obo:IAO_0000112 (example of usage)
+
+AnnotationAssertion(rdfs:label obo:IAO_0000112 "example of usage")
 
 # Annotation Property: obo:IAO_0000426 (obo:IAO_0000426)
 
@@ -6579,6 +6588,49 @@ AnnotationAssertion(rdfs:label obo:RO_0018034 "is protonated form of")
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018034 <https://github.com/oborel/obo-relations/issues/643>)
 SubObjectPropertyOf(obo:RO_0018034 obo:RO_0018030)
 TransitiveObjectProperty(obo:RO_0018034)
+
+# Object Property: obo:RO_0018036 (is tautomer of)
+
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018036 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018036 "2023-03-18T23:49:31Z"^^xsd:dateTime)
+AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018036 <http://purl.obolibrary.org/obo/chebi#is_tautomer_of>)
+AnnotationAssertion(rdfs:label obo:RO_0018036 "is tautomer of"@en)
+SubObjectPropertyOf(obo:RO_0018036 obo:RO_0018030)
+
+# Object Property: obo:RO_0018037 (is substitutent group from)
+
+AnnotationAssertion(obo:IAO_0000112 obo:RO_0018037 <>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018037 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018037 "2023-03-18T23:49:31Z"^^xsd:dateTime)
+AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018037 <http://purl.obolibrary.org/obo/chebi#is_substituent_group_from>)
+AnnotationAssertion(rdfs:label obo:RO_0018037 "is substitutent group from"@en)
+SubObjectPropertyOf(obo:RO_0018037 obo:RO_0018030)
+
+# Object Property: obo:RO_0018038 (has functional parent)
+
+AnnotationAssertion(obo:IAO_0000112 obo:RO_0018038 "hydrocortamate hydrochloride (CHEBI:50854) has parent hydride hydrocortamate (CHEBI:50851)")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018038 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018038 "2023-03-18T23:49:31Z"^^xsd:dateTime)
+AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018038 <http://purl.obolibrary.org/obo/chebi#has_functional_parent>)
+AnnotationAssertion(rdfs:label obo:RO_0018038 "has functional parent"@en)
+SubObjectPropertyOf(obo:RO_0018038 obo:RO_0018030)
+
+# Object Property: obo:RO_0018039 (is enantiomer of)
+
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018039 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018039 "2023-03-18T23:49:31Z"^^xsd:dateTime)
+AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018039 <http://purl.obolibrary.org/obo/chebi#is_enantiomer_of>)
+AnnotationAssertion(rdfs:label obo:RO_0018039 "is enantiomer of"@en)
+SubObjectPropertyOf(obo:RO_0018039 obo:RO_0018030)
+
+# Object Property: obo:RO_0018040 (has parent hydride)
+
+AnnotationAssertion(obo:IAO_0000112 obo:RO_0018040 "pyranine (CHEBI:52083) has parent hydride pyrene (CHEBI:39106). Pyrene is molecule with four fused benzene rings, whereas pyranine has the same core ring structure with additional sulfates.")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018040 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018040 "2023-03-18T23:49:31Z"^^xsd:dateTime)
+AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018040 <http://purl.obolibrary.org/obo/chebi#has_parent_hydride>)
+AnnotationAssertion(rdfs:label obo:RO_0018040 "has parent hydride"@en)
+SubObjectPropertyOf(obo:RO_0018040 obo:RO_0018030)
 
 # Object Property: obo:RO_0019000 (regulates characteristic)
 

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -6600,6 +6600,7 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018036 "2023-
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018036 <http://purl.obolibrary.org/obo/chebi#is_tautomer_of>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:RO_0018036 "is desmotrope of")
 AnnotationAssertion(rdfs:label obo:RO_0018036 "is tautomer of"@en)
+AnnotationAssertion(rdfs:seeAlso obo:RO_0018036 <https://github.com/oborel/obo-relations/issues/697>)
 SubObjectPropertyOf(obo:RO_0018036 obo:RO_0018030)
 SymmetricObjectProperty(obo:RO_0018036)
 
@@ -6610,6 +6611,7 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018037 <ht
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018037 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018037 <http://purl.obolibrary.org/obo/chebi#is_substituent_group_from>)
 AnnotationAssertion(rdfs:label obo:RO_0018037 "is substitutent group from"@en)
+AnnotationAssertion(rdfs:seeAlso obo:RO_0018037 <https://github.com/oborel/obo-relations/issues/697>)
 SubObjectPropertyOf(obo:RO_0018037 obo:RO_0018030)
 
 # Object Property: obo:RO_0018038 (has functional parent)
@@ -6619,6 +6621,7 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018038 <ht
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018038 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018038 <http://purl.obolibrary.org/obo/chebi#has_functional_parent>)
 AnnotationAssertion(rdfs:label obo:RO_0018038 "has functional parent"@en)
+AnnotationAssertion(rdfs:seeAlso obo:RO_0018038 <https://github.com/oborel/obo-relations/issues/697>)
 SubObjectPropertyOf(obo:RO_0018038 obo:RO_0018030)
 
 # Object Property: obo:RO_0018039 (is enantiomer of)
@@ -6632,6 +6635,7 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018039 "2023-
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018039 <http://purl.obolibrary.org/obo/chebi#is_enantiomer_of>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:RO_0018039 "is optical isomer of")
 AnnotationAssertion(rdfs:label obo:RO_0018039 "is enantiomer of"@en)
+AnnotationAssertion(rdfs:seeAlso obo:RO_0018039 <https://github.com/oborel/obo-relations/issues/697>)
 SubObjectPropertyOf(obo:RO_0018039 obo:RO_0018030)
 SymmetricObjectProperty(obo:RO_0018039)
 
@@ -6643,6 +6647,7 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018040 <ht
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018040 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018040 <http://purl.obolibrary.org/obo/chebi#has_parent_hydride>)
 AnnotationAssertion(rdfs:label obo:RO_0018040 "has parent hydride"@en)
+AnnotationAssertion(rdfs:seeAlso obo:RO_0018040 <https://github.com/oborel/obo-relations/issues/697>)
 SubObjectPropertyOf(obo:RO_0018040 obo:RO_0018030)
 
 # Object Property: obo:RO_0019000 (regulates characteristic)

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -6592,6 +6592,9 @@ TransitiveObjectProperty(obo:RO_0018034)
 # Object Property: obo:RO_0018036 (is tautomer of)
 
 AnnotationAssertion(obo:IAO_0000112 obo:RO_0018036 "3-carboxy-3-mercaptopropanoate (CHEBI:38707) is tautomer of 1,2-dicarboxyethanethiolate (CHEBI:38709) because 3-carboxy-3-mercaptopropanoate is deprotonated on the carboxylic acid whereas 1,2-dicarboxyethanethiolate is deprotonated on the secondary thiol.")
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0018036 "Two chemicals are tautomers if they can be readily interconverted.
+
+This commonly refers to prototropy in which a hydrogen's position is changed, such as between ketones and enols. This is also often observed in heterocyclic rings, e.g., ones containing nitrogens and/or have aryl functional groups containing heteroatoms.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018036 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018036 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018036 <http://purl.obolibrary.org/obo/chebi#is_tautomer_of>)
@@ -6618,6 +6621,7 @@ SubObjectPropertyOf(obo:RO_0018038 obo:RO_0018030)
 
 # Object Property: obo:RO_0018039 (is enantiomer of)
 
+AnnotationAssertion(obo:IAO_0000118 obo:RO_0018039 "dexmedetomidine hydrochloride (CHEBI:31472) is enantiomer of levomedetomidine hydrochloride (CHEBI:48557) because the stereochemistry of the central chiral carbon is swapped.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018039 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018039 "2023-03-18T23:49:31Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018039 <http://purl.obolibrary.org/obo/chebi#is_enantiomer_of>)

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -6595,8 +6595,8 @@ AnnotationAssertion(Annotation(rdfs:seeAlso obo:CHEBI_38707) Annotation(rdfs:see
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0018036 "Two chemicals are tautomers if they can be readily interconverted.
 
 This commonly refers to prototropy in which a hydrogen's position is changed, such as between ketones and enols. This is also often observed in heterocyclic rings, e.g., ones containing nitrogens and/or have aryl functional groups containing heteroatoms.")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018036 <https://orcid.org/0000-0003-4423-4370>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018036 "2023-03-18T23:49:31Z"^^xsd:dateTime)
+AnnotationAssertion(dc:creator obo:RO_0018036 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(dc:date obo:RO_0018036 "2023-03-18T23:49:31Z")
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018036 <http://purl.obolibrary.org/obo/chebi#is_tautomer_of>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:RO_0018036 "is desmotrope of")
 AnnotationAssertion(rdfs:label obo:RO_0018036 "is tautomer of"@en)
@@ -6608,8 +6608,8 @@ SymmetricObjectProperty(obo:RO_0018036)
 
 AnnotationAssertion(Annotation(rdfs:seeAlso obo:CHEBI_30795) Annotation(rdfs:seeAlso obo:CHEBI_58957) obo:IAO_0000112 obo:RO_0018037 "carboxylatoacetyl group (CHEBI:58957) is substituent group from malonate(1-) (CHEBI:30795)")
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0018037 "Group A is a substituent group from Chemical B if A represents the functional part of A and includes information about where it is connected. A is not itself a chemical with a fully formed chemical graph, but is rather a partial graph with one or more connection points that can be used to attach to another chemical graph, typically as a functionalization.")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018037 <https://orcid.org/0000-0003-4423-4370>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018037 "2023-03-18T23:49:31Z"^^xsd:dateTime)
+AnnotationAssertion(dc:creator obo:RO_0018037 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(dc:date obo:RO_0018037 "2023-03-18T23:49:31Z")
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018037 <http://purl.obolibrary.org/obo/chebi#is_substituent_group_from>)
 AnnotationAssertion(rdfs:label obo:RO_0018037 "is substitutent group from"@en)
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018037 <https://github.com/oborel/obo-relations/issues/697>)
@@ -6621,8 +6621,8 @@ AnnotationAssertion(Annotation(rdfs:seeAlso obo:CHEBI_50851) Annotation(rdfs:see
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0018038 "Chemical A has functional parent Chemical B if there is chemical transformation through which chemical B can be produced from chemical A. 
 
 For example, the relationship between a salt and a freebased compound is a \"has functional parent\" relationship.")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018038 <https://orcid.org/0000-0003-4423-4370>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018038 "2023-03-18T23:49:31Z"^^xsd:dateTime)
+AnnotationAssertion(dc:creator obo:RO_0018038 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(dc:date obo:RO_0018038 "2023-03-18T23:49:31Z")
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018038 <http://purl.obolibrary.org/obo/chebi#has_functional_parent>)
 AnnotationAssertion(rdfs:label obo:RO_0018038 "has functional parent"@en)
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018038 <https://github.com/oborel/obo-relations/issues/697>)
@@ -6634,8 +6634,8 @@ AnnotationAssertion(Annotation(rdfs:comment obo:CHEBI_48557) Annotation(rdfs:see
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0018039 "Chemicals A and B are enantiomers if they share the same molecular graph except the change of the configuration of substituents around exactly one chiral center.
 
 A chemical with no chiral centers can not have an enantiomer. A chemical with multiple chiral centers can have multiple enantiomers, but its enantiomers are not themselves enantiomers (they are diastereomers).")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018039 <https://orcid.org/0000-0003-4423-4370>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018039 "2023-03-18T23:49:31Z"^^xsd:dateTime)
+AnnotationAssertion(dc:creator obo:RO_0018039 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(dc:date obo:RO_0018039 "2023-03-18T23:49:31Z")
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018039 <http://purl.obolibrary.org/obo/chebi#is_enantiomer_of>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:RO_0018039 "is optical isomer of")
 AnnotationAssertion(rdfs:label obo:RO_0018039 "is enantiomer of"@en)
@@ -6647,8 +6647,8 @@ SymmetricObjectProperty(obo:RO_0018039)
 
 AnnotationAssertion(Annotation(rdfs:seeAlso obo:CHEBI_39106) Annotation(rdfs:seeAlso obo:CHEBI_52083) obo:IAO_0000112 obo:RO_0018040 "pyranine (CHEBI:52083) has parent hydride pyrene (CHEBI:39106). Pyrene is molecule with four fused benzene rings, whereas pyranine has the same core ring structure with additional sulfates.")
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0018040 "Chemical A has parent hydride Chemical B if there exists a molecular graphical transformation where functional groups on A are replaced with hydrogens in order to yield B.")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:RO_0018040 <https://orcid.org/0000-0003-4423-4370>)
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:RO_0018040 "2023-03-18T23:49:31Z"^^xsd:dateTime)
+AnnotationAssertion(dc:creator obo:RO_0018040 <https://orcid.org/0000-0003-4423-4370>)
+AnnotationAssertion(dc:date obo:RO_0018040 "2023-03-18T23:49:31Z")
 AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018040 <http://purl.obolibrary.org/obo/chebi#has_parent_hydride>)
 AnnotationAssertion(rdfs:label obo:RO_0018040 "has parent hydride"@en)
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018040 <https://github.com/oborel/obo-relations/issues/697>)


### PR DESCRIPTION
Closes #697 

This PR adds five new relationships corresponding to relationships in the ChEBI ontology as a follow-up to #662, where we added two relationships from ChEBI related to conjugate acids and bases.

| Identifier | Label | Description | ChEBI |
|-----------|--------|------------|------|
| RO:0018038 | has functional parent | Chemical A has functional parent Chemical B if there is chemical transformation through which chemical B can be produced from chemical A. <br><br> For example, the relationship between a salt and a freebased compound is a "has functional parent" relationship. | http://purl.obolibrary.org/obo/chebi#has_functional_parent |
| RO:0018040 | has parent hydride | Chemical A has parent hydride Chemical B if there exists a molecular graphical transformation where functional groups on A are replaced with hydrogens in order to yield B. | http://purl.obolibrary.org/obo/chebi#has_parent_hydride |
| RO:0018039 | is enantiomer of | Chemicals A and B are enantiomers if they share the same molecular graph except the change of the configuration of substituents around exactly one chiral center. <br><br> A chemical with no chiral centers can not have an enantiomer. A chemical with multiple chiral centers can have multiple enantiomers, but its enantiomers are not themselves enantiomers (they are diastereomers). | http://purl.obolibrary.org/obo/chebi#is_enantiomer_of |
| RO:0018037 | is substitutent group from | Group A is a substituent group from Chemical B if A represents the functional part of A and includes information about where it is connected. A is not itself a chemical with a fully formed chemical graph, but is rather a partial graph with one or more connection points that can be used to attach to another chemical graph, typically as a functionalization. | http://purl.obolibrary.org/obo/chebi#is_substituent_group_from |
| RO:0018036 | is tautomer of | Two chemicals are tautomers if they can be readily interconverted. <br><br> This commonly refers to prototropy in which a hydrogen's position is changed, such as between ketones and enols. This is also often observed in heterocyclic rings, e.g., ones containing nitrogens and/or have aryl functional groups containing heteroatoms. | http://purl.obolibrary.org/obo/chebi#is_tautomer_of |

I found it pretty difficult to write good definitions of each of these relationships based on the [ChEBI annotator guide](https://docs.google.com/document/d/1EZHaOEl-iPZPbqD_GRyIetDoA4U8U2SPr9Qk6RKVRc0/edit) because the sections on each of these first gave a really abstract definition (not specific enough), then an additional definition full of jargon (too specific), so I did my best to write human-usable definitions. These are assuming some chemistry knowledge, if desired, I can make them more accessible for a general audience (e.g., explaining the referenced chemistry concepts in full)

Each of the following has:

1. A parent relationship to "chemical relationship"
1. Reference to original issue
2. Example from ChEBI
3. Attribution / date of creation
4. Xref to equivalent ChEBI relationship

## Discussion on March 28, 2023 RO Meeting

- @bpeters42 mused whether importing them just because they're in ChEBI is a good idea (i.e., they still should be considered by someone who knows the domain well). He might have some other specific follow-up. In general I (charlie) think that each of these are valuable relations that are well-defined.