### PR TITLE
Relax the range restriction on 'has soma location'.

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -1670,7 +1670,7 @@ SubObjectPropertyOf(obo:RO_0002092 obo:RO_0002091)
 # Object Property: obo:RO_0002100 (has soma location)
 
 AnnotationAssertion(obo:IAO_0000114 obo:RO_0002100 obo:IAO_0000125)
-AnnotationAssertion(obo:IAO_0000115 obo:RO_0002100 "Relation between a neuron and an anatomical structure that its soma is part of."@en)
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0002100 "Relation between a neuron and an anatomical entity that its soma is part of."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:RO_0002100 <https://orcid.org/0000-0002-7073-9172>)
 AnnotationAssertion(obo:IAO_0000424 obo:RO_0002100 "<http://purl.obolibrary.org/obo/BFO_0000051> some (
    <http://purl.obolibrary.org/obo/GO_0043025> and   <http://purl.obolibrary.org/obo/BFO_0000050> some ?Y)")
@@ -1678,7 +1678,7 @@ AnnotationAssertion(obo:RO_0001900 obo:RO_0002100 obo:RO_0001901)
 AnnotationAssertion(rdfs:label obo:RO_0002100 "has soma location"@en)
 SubObjectPropertyOf(obo:RO_0002100 obo:RO_0002131)
 ObjectPropertyDomain(obo:RO_0002100 obo:CL_0000540)
-ObjectPropertyRange(obo:RO_0002100 obo:CARO_0000003)
+ObjectPropertyRange(obo:RO_0002100 obo:CARO_0000006)
 
 # Object Property: obo:RO_0002101 (fasciculates with)
 

--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -1670,7 +1670,7 @@ SubObjectPropertyOf(obo:RO_0002092 obo:RO_0002091)
 # Object Property: obo:RO_0002100 (has soma location)
 
 AnnotationAssertion(obo:IAO_0000114 obo:RO_0002100 obo:IAO_0000125)
-AnnotationAssertion(obo:IAO_0000115 obo:RO_0002100 "Relation between a neuron and an anatomical entity that its soma is part of."@en)
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0002100 "Relation between a neuron and a material anatomical entity that its soma is part of."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:RO_0002100 <https://orcid.org/0000-0002-7073-9172>)
 AnnotationAssertion(obo:IAO_0000424 obo:RO_0002100 "<http://purl.obolibrary.org/obo/BFO_0000051> some (
    <http://purl.obolibrary.org/obo/GO_0043025> and   <http://purl.obolibrary.org/obo/BFO_0000050> some ?Y)")


### PR DESCRIPTION
The 'has soma location' (RO:0002100) should not have a range restriction to CARO's 'connected anatomical structure' (CARO:0000003), but rather to 'material anatomical entity' (CARO:0000006), which does not state anything about the "connectedness" of the entity that a neuron's soma may be located in.

closes #702