### PR TITLE
Update chemical relation xrefs to skos:exactMatch

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -689,6 +689,7 @@ Declaration(AnnotationProperty(oboInOwl:inSubset))
 Declaration(AnnotationProperty(oboInOwl:source))
 Declaration(AnnotationProperty(rdfs:seeAlso))
 Declaration(AnnotationProperty(skos:closeMatch))
+Declaration(AnnotationProperty(skos:exactMatch))
 ############################
 #   Annotation Properties
 ############################
@@ -6593,9 +6594,9 @@ AnnotationAssertion(obo:IAO_0000115 obo:RO_0018033 "A is a deprotonated form of 
 
 This is a transitive relationship and follows this design pattern: https://oborel.github.io/obo-relations/direct-and-indirect-relations.")
 AnnotationAssertion(dc:creator obo:RO_0018033 <https://orcid.org/0000-0003-4423-4370>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018033 <http://purl.obolibrary.org/obo/chebi#is_conjugate_base_of>)
 AnnotationAssertion(rdfs:label obo:RO_0018033 "is deprotonated form of")
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018033 <https://github.com/oborel/obo-relations/issues/643>)
+AnnotationAssertion(skos:exactMatch obo:RO_0018033 <http://purl.obolibrary.org/obo/chebi#is_conjugate_base_of>)
 SubObjectPropertyOf(obo:RO_0018033 obo:RO_0018030)
 InverseObjectProperties(obo:RO_0018033 obo:RO_0018034)
 TransitiveObjectProperty(obo:RO_0018033)
@@ -6607,9 +6608,9 @@ AnnotationAssertion(obo:IAO_0000115 obo:RO_0018034 "A is a protonated form of B 
 
 This is a transitive relationship and follows this design pattern: https://oborel.github.io/obo-relations/direct-and-indirect-relations.")
 AnnotationAssertion(dc:creator obo:RO_0018034 <https://orcid.org/0000-0003-4423-4370>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018034 <http://purl.obolibrary.org/obo/chebi#is_conjugate_acid_of>)
 AnnotationAssertion(rdfs:label obo:RO_0018034 "is protonated form of")
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018034 <https://github.com/oborel/obo-relations/issues/643>)
+AnnotationAssertion(skos:exactMatch obo:RO_0018034 <http://purl.obolibrary.org/obo/chebi#is_conjugate_acid_of>)
 SubObjectPropertyOf(obo:RO_0018034 obo:RO_0018030)
 TransitiveObjectProperty(obo:RO_0018034)
 
@@ -6639,10 +6640,10 @@ AnnotationAssertion(obo:IAO_0000115 obo:RO_0018036 "Two chemicals are tautomers 
 This commonly refers to prototropy in which a hydrogen's position is changed, such as between ketones and enols. This is also often observed in heterocyclic rings, e.g., ones containing nitrogens and/or have aryl functional groups containing heteroatoms.")
 AnnotationAssertion(dc:creator obo:RO_0018036 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(dc:date obo:RO_0018036 "2023-03-18T23:49:31Z")
-AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018036 <http://purl.obolibrary.org/obo/chebi#is_tautomer_of>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:RO_0018036 "is desmotrope of")
 AnnotationAssertion(rdfs:label obo:RO_0018036 "is tautomer of"@en)
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018036 <https://github.com/oborel/obo-relations/issues/697>)
+AnnotationAssertion(skos:exactMatch obo:RO_0018036 <http://purl.obolibrary.org/obo/chebi#is_tautomer_of>)
 SubObjectPropertyOf(obo:RO_0018036 obo:RO_0018030)
 SymmetricObjectProperty(obo:RO_0018036)
 
@@ -6652,9 +6653,9 @@ AnnotationAssertion(Annotation(rdfs:seeAlso obo:CHEBI_30795) Annotation(rdfs:see
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0018037 "Group A is a substituent group from Chemical B if A represents the functional part of A and includes information about where it is connected. A is not itself a chemical with a fully formed chemical graph, but is rather a partial graph with one or more connection points that can be used to attach to another chemical graph, typically as a functionalization.")
 AnnotationAssertion(dc:creator obo:RO_0018037 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(dc:date obo:RO_0018037 "2023-03-18T23:49:31Z")
-AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018037 <http://purl.obolibrary.org/obo/chebi#is_substituent_group_from>)
 AnnotationAssertion(rdfs:label obo:RO_0018037 "is substitutent group from"@en)
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018037 <https://github.com/oborel/obo-relations/issues/697>)
+AnnotationAssertion(skos:exactMatch obo:RO_0018037 <http://purl.obolibrary.org/obo/chebi#is_substituent_group_from>)
 SubObjectPropertyOf(obo:RO_0018037 obo:RO_0018030)
 
 # Object Property: obo:RO_0018038 (has functional parent)
@@ -6665,9 +6666,9 @@ AnnotationAssertion(obo:IAO_0000115 obo:RO_0018038 "Chemical A has functional pa
 For example, the relationship between a salt and a freebased compound is a \"has functional parent\" relationship.")
 AnnotationAssertion(dc:creator obo:RO_0018038 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(dc:date obo:RO_0018038 "2023-03-18T23:49:31Z")
-AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018038 <http://purl.obolibrary.org/obo/chebi#has_functional_parent>)
 AnnotationAssertion(rdfs:label obo:RO_0018038 "has functional parent"@en)
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018038 <https://github.com/oborel/obo-relations/issues/697>)
+AnnotationAssertion(skos:exactMatch obo:RO_0018038 <http://purl.obolibrary.org/obo/chebi#has_functional_parent>)
 SubObjectPropertyOf(obo:RO_0018038 obo:RO_0018030)
 
 # Object Property: obo:RO_0018039 (is enantiomer of)
@@ -6678,10 +6679,10 @@ AnnotationAssertion(obo:IAO_0000115 obo:RO_0018039 "Chemicals A and B are enanti
 A chemical with no chiral centers can not have an enantiomer. A chemical with multiple chiral centers can have multiple enantiomers, but its enantiomers are not themselves enantiomers (they are diastereomers).")
 AnnotationAssertion(dc:creator obo:RO_0018039 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(dc:date obo:RO_0018039 "2023-03-18T23:49:31Z")
-AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018039 <http://purl.obolibrary.org/obo/chebi#is_enantiomer_of>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:RO_0018039 "is optical isomer of")
 AnnotationAssertion(rdfs:label obo:RO_0018039 "is enantiomer of"@en)
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018039 <https://github.com/oborel/obo-relations/issues/697>)
+AnnotationAssertion(skos:exactMatch obo:RO_0018039 <http://purl.obolibrary.org/obo/chebi#is_enantiomer_of>)
 SubObjectPropertyOf(obo:RO_0018039 obo:RO_0018030)
 SymmetricObjectProperty(obo:RO_0018039)
 
@@ -6691,9 +6692,9 @@ AnnotationAssertion(Annotation(rdfs:seeAlso obo:CHEBI_39106) Annotation(rdfs:see
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0018040 "Chemical A has parent hydride Chemical B if there exists a molecular graphical transformation where functional groups on A are replaced with hydrogens in order to yield B.")
 AnnotationAssertion(dc:creator obo:RO_0018040 <https://orcid.org/0000-0003-4423-4370>)
 AnnotationAssertion(dc:date obo:RO_0018040 "2023-03-18T23:49:31Z")
-AnnotationAssertion(oboInOwl:hasDbXref obo:RO_0018040 <http://purl.obolibrary.org/obo/chebi#has_parent_hydride>)
 AnnotationAssertion(rdfs:label obo:RO_0018040 "has parent hydride"@en)
 AnnotationAssertion(rdfs:seeAlso obo:RO_0018040 <https://github.com/oborel/obo-relations/issues/697>)
+AnnotationAssertion(skos:exactMatch obo:RO_0018040 <http://purl.obolibrary.org/obo/chebi#has_parent_hydride>)
 SubObjectPropertyOf(obo:RO_0018040 obo:RO_0018030)
 
 # Object Property: obo:RO_0019000 (regulates characteristic)


### PR DESCRIPTION
Suggested in https://github.com/oborel/obo-relations/pull/728#discussion_r1238352410, this PR switches the chemical relationships I've recently added to use skos:exactMatch instead of oio:hasDbXref.