### PR TITLE
Removing ReflexiveObjectProperty(obo:RO_0017003)

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -6511,7 +6511,6 @@ AnnotationAssertion(dc:contributor obo:RO_0017003 <https://orcid.org/0000-0003-1
 AnnotationAssertion(rdfs:label obo:RO_0017003 "positively correlated with"@en)
 SubObjectPropertyOf(obo:RO_0017003 obo:RO_0002610)
 SymmetricObjectProperty(obo:RO_0017003)
-ReflexiveObjectProperty(obo:RO_0017003)
 
 # Object Property: obo:RO_0017004 (negatively correlated with)
 


### PR DESCRIPTION
See also #747 

This is a very dangerous characteristic to assert - ideally we should add some QC to prevent it from happening again.