### PR TITLE
Correct number of days in 2 years (730, not 630)

### DIFF
--- a/.github/workflows/stale-issues-and-prs.yml
+++ b/.github/workflows/stale-issues-and-prs.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@v7
         with:
-          days-before-issue-stale: 630
+          days-before-issue-stale: 730
           days-before-issue-close: 60
           close-issue-label: 'autoclosed-unfixed'
           close-issue-reason: 'not_planned'


### PR DESCRIPTION
I wondered why issue #530 was closed as not having seen any activity in 2 years when it hadn't been 2 years. This is why: this workflow had
>  days-before-issue-stale: 630
when it should be 730.