### PR TITLE
Restore parent of 'regulates in another organism' to be 'causally upstream of or within'.

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -1492,7 +1492,7 @@ AnnotationAssertion(obo:IAO_0000117 obo:RO_0002010 <https://orcid.org/0000-0002-
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:RO_0002010 "regulates in other organism")
 AnnotationAssertion(oboInOwl:inSubset obo:RO_0002010 obo:valid_for_go_ontology)
 AnnotationAssertion(rdfs:label obo:RO_0002010 "regulates in another organism")
-SubObjectPropertyOf(obo:RO_0002010 obo:RO_0002211)
+SubObjectPropertyOf(obo:RO_0002010 obo:RO_0002418)
 ObjectPropertyDomain(obo:RO_0002010 obo:BFO_0000015)
 ObjectPropertyRange(obo:RO_0002010 obo:BFO_0000015)
 


### PR DESCRIPTION
This corrects an inadvertent change within #761.