### PR TITLE
Narrow synonym arising from pull 742 discussion

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -2138,6 +2138,7 @@ AnnotationAssertion(obo:IAO_0000117 obo:RO_0002162 <https://orcid.org/0000-0002-
 AnnotationAssertion(obo:IAO_0000119 obo:RO_0002162 <http://www.ncbi.nlm.nih.gov/pubmed/17921072>)
 AnnotationAssertion(obo:IAO_0000119 obo:RO_0002162 <http://www.ncbi.nlm.nih.gov/pubmed/20973947>)
 AnnotationAssertion(oboInOwl:inSubset obo:RO_0002162 subsets:ro-eco)
+AnnotationAssertion(oboInOwl:hasNarrowSynonym obo:RO_0002162 "life cycle stage of"@en)
 AnnotationAssertion(rdfs:comment obo:RO_0002162 "Connects a biological entity to its taxon of origin.")
 AnnotationAssertion(rdfs:label obo:RO_0002162 "in taxon")
 AnnotationAssertion(rdfs:seeAlso obo:RO_0002162 <https://github.com/obophenotype/uberon/wiki/Taxon-constraints>)


### PR DESCRIPTION
Discussion in https://github.com/oborel/obo-relations/pull/742 led to understanding that "in taxon" allows both organism and process/life stage assignment to organism taxon.  The "life cycle stage of" synonymy allows "in taxon" to be found for life cycle association.