### PR TITLE
Add regulates to relations which propagate 'in taxon'.

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -7173,6 +7173,7 @@ SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002206 obo:RO_0002162) obo:RO_00
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002207 obo:BFO_0000050) obo:RO_0002225)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002207 obo:RO_0001025) obo:RO_0002226)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002211 obo:RO_0002025) obo:RO_0002211)
+SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002211 obo:RO_0002162) obo:RO_0002162)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002211 obo:RO_0002313) obo:RO_0002011)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002211 obo:RO_0019000) obo:RO_0019000)
 SubObjectPropertyOf(ObjectPropertyChain(obo:RO_0002212 obo:RO_0002212) obo:RO_0002213)


### PR DESCRIPTION
The historical usage of 'regulates' assumes it is within a single organism. For this reason we have the term [regulates in another organism](http://purl.obolibrary.org/obo/RO_0002010) without that assumption. This PR adds 'regulates' to the relations which propagate 'in taxon'.

This is good for GO, but does seem to assume a biological context. I'm not sure if the definition of 'regulates' should be tweaked to make that context more clear.