### PR TITLE
Add new term 'has substitutable entity'

### DIFF
--- a/src/ontology/ro-edit.owl
+++ b/src/ontology/ro-edit.owl
@@ -6969,7 +6969,7 @@ SubObjectPropertyOf(obo:RO_0019002 obo:RO_0019000)
 
 # Object Property: obo:RO_0019003 (has substitutable entity)
 
-AnnotationAssertion(obo:IAO_0000112 obo:RO_0019003 "Given a 'molecular function' f, f is 'enabled by' an 'information biomacromolecule' i. i 'has substitutable entity' both x and y, instances of two different gene products, either of which may play the role of i in its biological context.")
+AnnotationAssertion(obo:IAO_0000112 obo:RO_0019003 "Given individuals f, i, x, and y, where f is a 'molecular function', i is an 'information biomacromolecule', and x and y are instances of different types of gene products, if f 'enabled by' i within an OWL model of a biological pathway, and i 'has substitutable entity' both x and y, then either x or y are valid enablers of function f within the modeled biological context.")
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0019003 "Relates one individual to another which is capable of standing in for the first individual in its other relations to other individuals.")
 AnnotationAssertion(obo:IAO_0000117 obo:RO_0019003 <https://orcid.org/0000-0002-8688-6599>)
 AnnotationAssertion(oboInOwl:inSubset obo:RO_0019003 obo:valid_for_gocam)


### PR DESCRIPTION
Fixes #863.

Label: has substitutable entity

Definition: Relates one individual to another which is capable of standing in for the first individual in its other relations to other individuals.

Example of usage: Given individuals f, i, x, and y, where f is a 'molecular function', i is an 'information biomacromolecule', and x and y are instances of different types of gene products, if f 'enabled by' i within an OWL model of a biological pathway, and i 'has substitutable entity' both x and y, then either x or y are valid enablers of function f within the modeled biological context.